### PR TITLE
Fix agent config and watchlist duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,14 @@ The terminal defaults to:
 }
 ```
 
-To use a different Ollama model, edit `data/runtime/agents/active_agent.json` after first run:
+`data/runtime/agents/active_agent.json` is created automatically on first run. To use a different Ollama model, either use the Agents tab command box:
+
+```text
+/agent ollama gemma4:e2b
+```
+
+or edit `data/runtime/agents/active_agent.json`:
+
 ```json
 {
   "selected_preset": "ollama",
@@ -331,7 +338,11 @@ To use a different Ollama model, edit `data/runtime/agents/active_agent.json` af
 }
 ```
 
-Or switch from inside the TUI: **Agents tab → Agent Settings → enter model name**.
+You can also keep the current backend and only change its model:
+
+```text
+/model mistral
+```
 
 **Step 5 — Run the terminal**
 ```bash
@@ -351,7 +362,11 @@ pip install mlx-vlm
 # Model (~3 GB) downloads automatically on first use
 ```
 
-To use this backend, select the `gemma4_mlx` preset in the Agents tab or in `data/runtime/agents/active_agent.json`.
+To use this backend, run this in the Agents tab command box or set the same preset in `data/runtime/agents/active_agent.json`:
+
+```text
+/agent gemma4_mlx
+```
 
 ---
 
@@ -367,16 +382,25 @@ npm install -g @anthropic-ai/claude-code   # or via brew
 claude login
 ```
 
-Then set `active_agent.json` backend to `"claude"`, or switch from the TUI.
+Then set `active_agent.json` backend to `"claude"`, or switch from the TUI:
+
+```text
+/agent claude
+```
 
 ---
 
 ### Switching backends at runtime
 
-All three backends are hot-swappable without restarting the terminal. In the TUI:
+All three backends are hot-swappable without restarting the terminal. In the Agents tab chat box:
 
-```
-Agents tab → Agent Settings (gear icon) → select backend → Save
+```text
+/agent
+/agent list
+/agent ollama gemma4:e2b
+/agent gemma4_mlx
+/agent claude
+/model qwen2
 ```
 
 The setting persists to `data/runtime/agents/active_agent.json`.

--- a/apps/tui/dashboard_tui.py
+++ b/apps/tui/dashboard_tui.py
@@ -111,6 +111,12 @@ from backend.agents.agent_analyst import (
     load_agent_archive_history,
     load_agent_history,
 )
+from backend.agents.runtime_config import (
+    ACTIVE_AGENT_FILE,
+    list_agent_backends,
+    load_active_agent_config,
+    set_active_agent,
+)
 from backend.quant_pro.stock_report import build_stock_report
 from backend.trading.tui_trading_engine import TUITradingEngine
 from backend.trading.paper_execution import PaperExecutionService
@@ -293,6 +299,21 @@ def _watchlist_entry_key(item: dict) -> str:
     return str((item or {}).get("key") or "")
 
 
+def _dedupe_watchlist_entries(entries: list[dict]) -> list[dict]:
+    deduped: list[dict] = []
+    seen: set[str] = set()
+    for item in entries or []:
+        normalized = _normalize_watchlist_entry(item)
+        if not normalized:
+            continue
+        key = _watchlist_entry_key(normalized)
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        deduped.append(normalized)
+    return deduped
+
+
 def _build_sell_holdings_map(positions: list[dict] | None) -> dict[str, int]:
     holdings: dict[str, int] = {}
     for pos in positions or []:
@@ -337,15 +358,17 @@ def _load_watchlist() -> list[dict]:
         try:
             data = _json.loads(WATCHLIST_FILE.read_text())
             if isinstance(data, list) and data:
-                rows = [_normalize_watchlist_entry(item) for item in data]
-                return [row for row in rows if row]
+                rows = _dedupe_watchlist_entries(data)
+                if len(rows) != len(data):
+                    _save_watchlist(rows)
+                return rows
         except Exception:
             pass
-    return [_stock_watchlist_entry(sym) for sym in DEFAULT_WATCHLIST]
+    return _dedupe_watchlist_entries([_stock_watchlist_entry(sym) for sym in DEFAULT_WATCHLIST])
 
 def _save_watchlist(entries: list[dict]) -> None:
     ensure_dir(WATCHLIST_FILE.parent)
-    WATCHLIST_FILE.write_text(_json.dumps(entries, indent=2))
+    WATCHLIST_FILE.write_text(_json.dumps(_dedupe_watchlist_entries(entries), indent=2))
 
 
 def _ensure_csv_file(path: Path, columns: list[str]) -> None:
@@ -3594,7 +3617,7 @@ class NepseDashboard(App):
                             yield Static("COMPOSER", classes="panel-title", id="agent-compose-title")
                             with Vertical(id="agent-chat-footer"):
                                 yield Static("", id="agent-chat-hint")
-                                yield Input(id="agent-input", placeholder="Ask the agent...  (/history, /recent, /stop)")
+                                yield Input(id="agent-input", placeholder="Ask the agent...  (/agent list, /model gemma4:e2b, /stop)")
 
             # ── 6 ORDERS (Order Management) ──
             with Vertical(id="orders", classes="tab-pane"):
@@ -4955,6 +4978,21 @@ class NepseDashboard(App):
         meta = dict((getattr(self, "_agent_analysis", {}) or {}).get("agent_runtime_meta") or {})
         return str(meta.get("provider") or "gemma4_mlx")
 
+    def _agent_runtime_summary(self) -> str:
+        cfg = load_active_agent_config()
+        preset = str(cfg.get("selected_preset") or cfg.get("backend") or "ollama")
+        backend = str(cfg.get("backend") or preset)
+        model = str(cfg.get("model") or "").strip() or "default"
+        return f"{preset} backend={backend} model={model}"
+
+    def _agent_backends_help(self) -> str:
+        backends = list_agent_backends()
+        parts = [
+            f"{row['id']} ({row.get('model') or 'no default model'})"
+            for row in backends
+        ]
+        return "Agent backends: " + ", ".join(parts)
+
     def _stop_active_agent_chat(self, *, announce: bool = True) -> bool:
         proc = getattr(self, "_agent_chat_process", None)
         if proc is None:
@@ -5977,7 +6015,7 @@ class NepseDashboard(App):
             f"[#888888]Super:[/] [bold {AMBER}]{n_super}[/]   "
             f"[#888888]Regime:[/] [{YELLOW}]{regime}[/]   "
             f"[#888888]Updated:[/] [{LABEL}]{age_str}[/]   "
-            f"[#555555]A=Analyze  │  /history  │  /recent[/]"
+            f"[#555555]A=Analyze  │  /agent  │  /model  │  /history[/]"
         ))
 
     def _populate_agent_meta_headers(self, analysis: dict) -> None:
@@ -6343,8 +6381,54 @@ class NepseDashboard(App):
                 return True
             self._set_status("No active agent response to stop")
             return True
+        if command in {"/agent", "/agent status"}:
+            summary = self._agent_runtime_summary()
+            self._append_chat_note(f"Active agent: {summary}. Config: {ACTIVE_AGENT_FILE}")
+            self._set_status(f"Active agent: {summary}")
+            return True
+        if command in {"/agent list", "/agents", "/backends"}:
+            help_text = self._agent_backends_help()
+            self._append_chat_note(help_text)
+            self._set_status(help_text)
+            return True
+        if command.startswith("/agent "):
+            try:
+                parts = shlex.split(raw)
+                if len(parts) < 2:
+                    raise ValueError("Usage: /agent <ollama|gemma4_mlx|gemma4_experimental|claude> [model]")
+                preset = parts[1].strip()
+                model = parts[2].strip() if len(parts) >= 3 else None
+                cfg = set_active_agent(preset, model=model)
+                summary = self._agent_runtime_summary()
+                self._append_chat_note(f"Agent switched: {summary}")
+                self._set_status(f"Agent switched to {cfg.get('selected_preset')} | model {cfg.get('model') or 'default'}")
+                self._populate_agent_tab()
+                return True
+            except Exception as exc:
+                self._set_status(f"Agent switch failed: {exc}")
+                return True
+        if command.startswith("/model"):
+            try:
+                parts = shlex.split(raw)
+                if len(parts) < 2:
+                    summary = self._agent_runtime_summary()
+                    self._append_chat_note(f"Active model: {summary}")
+                    self._set_status(f"Active agent: {summary}")
+                    return True
+                model = " ".join(parts[1:]).strip()
+                cfg = load_active_agent_config()
+                preset = str(cfg.get("selected_preset") or cfg.get("backend") or "ollama")
+                saved = set_active_agent(preset, model=model)
+                summary = self._agent_runtime_summary()
+                self._append_chat_note(f"Agent model updated: {summary}")
+                self._set_status(f"Agent model set to {saved.get('model')}")
+                self._populate_agent_tab()
+                return True
+            except Exception as exc:
+                self._set_status(f"Model update failed: {exc}")
+                return True
         if command == "/help":
-            self._set_status("Agent chat commands: /history, /recent, /clear, /stop")
+            self._set_status("Agent commands: /agent, /agent list, /agent ollama gemma4:e2b, /model <name>, /history, /recent, /clear, /stop")
             return True
         return False
 
@@ -9578,9 +9662,9 @@ class NepseDashboard(App):
                 continue
             seen.add(sym)
             symbols.append(sym)
-        self._live_watchlist = [_stock_watchlist_entry(sym) for sym in symbols]
+        self._live_watchlist = _dedupe_watchlist_entries([_stock_watchlist_entry(sym) for sym in symbols])
         local_extras = [item for item in self._paper_watchlist if str(item.get("kind") or "stock") != "stock"]
-        self._watchlist = list(self._live_watchlist) + local_extras
+        self._watchlist = _merge_watchlist_entries(self._live_watchlist, local_extras)
         bundle = dict(getattr(self, "_tms_bundle", None) or {})
         bundle["watchlist"] = snapshot
         self._tms_bundle = bundle
@@ -9659,10 +9743,12 @@ class NepseDashboard(App):
                 watchlist_source = "TMS"
             elif self._live_watchlist:
                 local_extras = [item for item in self._paper_watchlist if str(item.get("kind") or "stock") != "stock"]
-                self._watchlist = list(self._live_watchlist) + local_extras
+                self._watchlist = _merge_watchlist_entries(self._live_watchlist, local_extras)
                 watchlist_source = "CACHE"
             else:
-                self._watchlist = [item for item in self._paper_watchlist if str(item.get("kind") or "stock") != "stock"]
+                self._watchlist = _dedupe_watchlist_entries(
+                    [item for item in self._paper_watchlist if str(item.get("kind") or "stock") != "stock"]
+                )
                 watchlist_source = "TMS"
         else:
             self._watchlist, held_count = self._effective_paper_watchlist()

--- a/backend/agents/runtime_config.py
+++ b/backend/agents/runtime_config.py
@@ -91,6 +91,12 @@ def _default_active_agent_config() -> dict[str, Any]:
     return payload
 
 
+def _write_active_agent_config(payload: dict[str, Any]) -> dict[str, Any]:
+    ensure_dir(ACTIVE_AGENT_FILE.parent)
+    ACTIVE_AGENT_FILE.write_text(json.dumps(payload, indent=2, default=str))
+    return payload
+
+
 def _normalize_active_agent_config(raw: dict[str, Any] | None) -> dict[str, Any]:
     payload = dict(raw or {})
     selected_preset = str(payload.get("selected_preset") or payload.get("backend") or DEFAULT_AGENT_PRESET).strip().lower()
@@ -114,19 +120,18 @@ def _normalize_active_agent_config(raw: dict[str, Any] | None) -> dict[str, Any]
 
 def load_active_agent_config() -> dict[str, Any]:
     if not ACTIVE_AGENT_FILE.exists():
-        return _default_active_agent_config()
+        return save_active_agent_config(_default_active_agent_config())
     try:
         payload = json.loads(ACTIVE_AGENT_FILE.read_text())
     except Exception:
-        return _default_active_agent_config()
+        return save_active_agent_config(_default_active_agent_config())
     return _normalize_active_agent_config(payload if isinstance(payload, dict) else {})
 
 
 def save_active_agent_config(config: dict[str, Any] | None) -> dict[str, Any]:
     normalized = _normalize_active_agent_config(config)
     normalized["updated_at"] = time.time()
-    ACTIVE_AGENT_FILE.write_text(json.dumps(normalized, indent=2, default=str))
-    return normalized
+    return _write_active_agent_config(normalized)
 
 
 def set_active_agent(

--- a/tests/unit/test_agent_runtime_config.py
+++ b/tests/unit/test_agent_runtime_config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from backend.agents.runtime_config import load_active_agent_config, save_active_agent_config, set_active_agent
 
 
@@ -16,6 +18,9 @@ def test_active_agent_config_defaults_when_missing(tmp_path, monkeypatch):
     assert cfg["backend"] == "ollama"
     assert cfg["provider_label"] == "ollama"
     assert cfg["model"] == "llama3"
+    assert (tmp_path / "active_agent.json").exists()
+    saved = json.loads((tmp_path / "active_agent.json").read_text())
+    assert saved["backend"] == "ollama"
 
 
 def test_set_active_agent_persists_selected_backend(tmp_path, monkeypatch):
@@ -51,3 +56,18 @@ def test_save_active_agent_config_allows_model_override(tmp_path, monkeypatch):
     )
 
     assert payload["model"] == "custom/model"
+
+
+def test_active_agent_config_repairs_invalid_json(tmp_path, monkeypatch):
+    target = tmp_path / "active_agent.json"
+    target.write_text("{bad json")
+    monkeypatch.setattr(
+        "backend.agents.runtime_config.ACTIVE_AGENT_FILE",
+        target,
+        raising=False,
+    )
+
+    cfg = load_active_agent_config()
+
+    assert cfg["backend"] == "ollama"
+    assert json.loads(target.read_text())["backend"] == "ollama"

--- a/tests/unit/test_dashboard_issue8.py
+++ b/tests/unit/test_dashboard_issue8.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+
+from apps.tui import dashboard_tui as tui
+from backend.agents import runtime_config
+
+
+def test_watchlist_load_dedupes_and_repairs_existing_file(tmp_path, monkeypatch):
+    target = tmp_path / "watchlist.json"
+    target.write_text(
+        json.dumps(
+            [
+                "nabil",
+                {"kind": "stock", "symbol": "NABIL"},
+                {"kind": "forex", "key": "forex:USD", "label": "USD"},
+                {"kind": "forex", "key": "forex:USD", "label": "USD"},
+            ]
+        )
+    )
+    monkeypatch.setattr(tui, "WATCHLIST_FILE", target)
+
+    rows = tui._load_watchlist()
+
+    assert [row["key"] for row in rows] == ["stock:NABIL", "forex:USD"]
+    repaired = json.loads(target.read_text())
+    assert [row["key"] for row in repaired] == ["stock:NABIL", "forex:USD"]
+
+
+def test_agent_chat_command_can_switch_ollama_model(tmp_path, monkeypatch):
+    target = tmp_path / "active_agent.json"
+    monkeypatch.setattr(runtime_config, "ACTIVE_AGENT_FILE", target)
+    monkeypatch.setattr(tui, "ACTIVE_AGENT_FILE", target)
+    notes: list[str] = []
+    statuses: list[str] = []
+    populated: list[bool] = []
+
+    app = tui.NepseDashboard.__new__(tui.NepseDashboard)
+    app._append_chat_note = notes.append
+    app._set_status = statuses.append
+    app._populate_agent_tab = lambda: populated.append(True)
+
+    handled = tui.NepseDashboard._handle_agent_chat_command(app, "/agent ollama gemma4:e2b")
+
+    cfg = runtime_config.load_active_agent_config()
+    assert handled
+    assert cfg["backend"] == "ollama"
+    assert cfg["model"] == "gemma4:e2b"
+    assert notes and "gemma4:e2b" in notes[-1]
+    assert statuses and "Agent switched" in statuses[-1]
+    assert populated == [True]


### PR DESCRIPTION
## Summary
- Dedupe and repair persisted TUI watchlists so duplicate stock rows do not keep reappearing.
- Create `data/runtime/agents/active_agent.json` automatically on first run, and repair invalid JSON back to the safe Ollama default.
- Add Agents tab chat commands for runtime backend/model switching: `/agent`, `/agent list`, `/agent ollama gemma4:e2b`, and `/model <name>`.
- Update README agent instructions to match the actual TUI flow and remove the missing settings gear guidance.

## Why
Fixes the user-facing problems reported in #8: duplicate stocks, stale README agent instructions, missing automatic agent config generation, and no working in-TUI way to change the local agent/model.

Also fixes #7, where the documented Agent Settings gear did not exist in the TUI.

## Validation
- `python3 -m py_compile backend/agents/runtime_config.py apps/tui/dashboard_tui.py`
- `pytest tests/unit/test_agent_runtime_config.py tests/unit/test_dashboard_issue8.py -q`
- `pytest tests/unit -q`

Fixes #7
Fixes #8
