### PR TITLE
Harden TUI launch, market panels, and easy startup

### DIFF
--- a/apps/classic/dashboard.py
+++ b/apps/classic/dashboard.py
@@ -186,6 +186,7 @@ class MD:
                 lat = pd.DataFrame(columns=["symbol", "open", "high", "low", "close", "volume"])
 
             lat = lat[lat["symbol"] != "NEPSE"].copy()
+            lat = lat.drop_duplicates("symbol", keep="last")
             if not quotes.empty:
                 quote_fallback = quotes.rename(
                     columns={"ltp": "quote_ltp", "prev_close": "quote_prev", "vol": "quote_vol"}
@@ -216,10 +217,12 @@ class MD:
                 prv = pd.read_sql_query(
                     "SELECT symbol,close prev FROM stock_prices WHERE date=?",
                     c, params=(prv_d,))
+                prv = prv.drop_duplicates("symbol", keep="last")
                 df = df.merge(prv, on="symbol", how="left")
             else:
                 df["prev"] = pd.NA
 
+            df = df.drop_duplicates("symbol", keep="last")
             for col in ("open", "high", "low", "close", "volume", "quote_ltp", "quote_prev", "quote_vol", "prev"):
                 df[col] = pd.to_numeric(df[col], errors="coerce")
 

--- a/apps/tui/dashboard_tui.py
+++ b/apps/tui/dashboard_tui.py
@@ -371,6 +371,20 @@ def _save_watchlist(entries: list[dict]) -> None:
     WATCHLIST_FILE.write_text(_json.dumps(_dedupe_watchlist_entries(entries), indent=2))
 
 
+def _dedupe_symbol_rows(rows: list | tuple) -> list:
+    """Return one row per symbol, keeping the last row seen for duplicate symbols."""
+    deduped: dict[str, Any] = {}
+    for row in rows or []:
+        try:
+            symbol = str(row[0] or "").strip().upper()
+        except Exception:
+            continue
+        if not symbol:
+            continue
+        deduped[symbol] = row
+    return list(deduped.values())
+
+
 def _ensure_csv_file(path: Path, columns: list[str]) -> None:
     target = Path(path)
     ensure_dir(target.parent)
@@ -4058,8 +4072,6 @@ class NepseDashboard(App):
         self.query_one("#content", ContentSwitcher).current = name
         self._update_header()
         self._refresh_active_tab_view(force_watchlist_sync=True)
-        if name == "signals":
-            self._load_signals_async()
 
     # ── Actions ───────────────────────────────────────────────────────────────
 
@@ -8556,12 +8568,13 @@ class NepseDashboard(App):
                         "WHERE date=? AND symbol != 'NEPSE'",
                         (latest_date,)
                     ).fetchall()
+                    today_rows = _dedupe_symbol_rows(today_rows)
                     prev_map = {
                         r[0]: float(r[1])
-                        for r in conn.execute(
+                        for r in _dedupe_symbol_rows(conn.execute(
                             "SELECT symbol, close FROM stock_prices WHERE date=?",
                             (prev_date,)
-                        ).fetchall()
+                        ).fetchall())
                     }
                     avg_vol_map = {
                         r[0]: float(r[1]) if r[1] else 0.0
@@ -10115,11 +10128,12 @@ class NepseDashboard(App):
                     "WHERE date=? AND symbol != 'NEPSE'",
                     (latest_date,)
                 ).fetchall()
+                today_rows = _dedupe_symbol_rows(today_rows)
                 prev_map = {}
-                for r in conn.execute(
+                for r in _dedupe_symbol_rows(conn.execute(
                     "SELECT symbol, close FROM stock_prices WHERE date=?",
                     (prev_date,)
-                ).fetchall():
+                ).fetchall()):
                     prev_map[r[0]] = float(r[1])
 
                 # Get 20-day avg volume for vol ratio

--- a/backend/trading/tui_trading_engine.py
+++ b/backend/trading/tui_trading_engine.py
@@ -305,11 +305,11 @@ class TUITradingEngine:
                 self._log(f"Tick error: {e}")
                 logger.exception("TUI engine tick error")
 
-            # Sleep in small increments so stop() is responsive
-            for _ in range(10):
+            # Sleep in short increments so dashboard quit does not wait on a long polling sleep.
+            for _ in range(50):
                 if self._stop_flag:
                     break
-                time.sleep(1)
+                time.sleep(0.2)
 
         self._persist_state()
         self._log("Engine stopped")

--- a/tests/unit/test_dashboard_market_data.py
+++ b/tests/unit/test_dashboard_market_data.py
@@ -77,3 +77,66 @@ def test_md_refresh_uses_market_quotes_when_only_latest_session_exists(tmp_path,
     assert round(float(md.gainers.iloc[0]["chg"]), 2) == 10.0
     assert round(float(md.losers.iloc[0]["chg"]), 2) == -10.0
     assert len(md.quotes) == 2
+
+
+def test_md_refresh_dedupes_duplicate_symbol_session_rows(tmp_path, monkeypatch):
+    db_path = tmp_path / "dashboard.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE stock_prices (
+            symbol TEXT,
+            date TEXT,
+            open REAL,
+            high REAL,
+            low REAL,
+            close REAL,
+            volume REAL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE market_quotes (
+            raw_id INTEGER NOT NULL,
+            symbol TEXT NOT NULL,
+            security_id TEXT,
+            security_name TEXT,
+            last_traded_price REAL,
+            close_price REAL,
+            previous_close REAL,
+            percentage_change REAL,
+            total_trade_quantity REAL,
+            source TEXT NOT NULL,
+            fetched_at_utc TEXT NOT NULL
+        )
+        """
+    )
+    conn.executemany(
+        """
+        INSERT INTO stock_prices (symbol, date, open, high, low, close, volume)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            ("AAA", "2026-04-06", 100.0, 100.0, 100.0, 100.0, 1000.0),
+            ("AAA", "2026-04-06", 101.0, 101.0, 101.0, 100.0, 1000.0),
+            ("BBB", "2026-04-06", 100.0, 100.0, 100.0, 100.0, 1000.0),
+            ("AAA", "2026-04-07", 109.0, 111.0, 108.0, 110.0, 1500.0),
+            ("AAA", "2026-04-07", 109.0, 111.0, 108.0, 110.0, 1500.0),
+            ("BBB", "2026-04-07", 89.0, 91.0, 88.0, 90.0, 2500.0),
+            ("BBB", "2026-04-07", 89.0, 91.0, 88.0, 90.0, 2500.0),
+            ("NEPSE", "2026-04-07", 2700.0, 2710.0, 2690.0, 2705.0, 1500.0),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(classic_dashboard, "_db", lambda: sqlite3.connect(str(db_path)))
+
+    md = classic_dashboard.MD(5)
+
+    assert md.err is None
+    assert list(md.df["symbol"]) == ["AAA", "BBB"]
+    assert list(md.gainers["symbol"]) == ["AAA", "BBB"]
+    assert list(md.losers["symbol"]) == ["BBB", "AAA"]
+    assert list(md.vol_top["symbol"]) == ["BBB", "AAA"]

--- a/tests/unit/test_dashboard_tui_market_helpers.py
+++ b/tests/unit/test_dashboard_tui_market_helpers.py
@@ -1,0 +1,27 @@
+from apps.tui import dashboard_tui
+
+
+def test_dedupe_symbol_rows_keeps_last_duplicate():
+    rows = [
+        ("AAA", 100.0),
+        ("BBB", 200.0),
+        ("AAA", 101.0),
+    ]
+
+    assert dashboard_tui._dedupe_symbol_rows(rows) == [
+        ("AAA", 101.0),
+        ("BBB", 200.0),
+    ]
+
+
+def test_dedupe_symbol_rows_normalizes_symbol_case():
+    rows = [
+        ("aaa", 100.0),
+        ("AAA", 101.0),
+        (" bbb ", 200.0),
+    ]
+
+    assert dashboard_tui._dedupe_symbol_rows(rows) == [
+        ("AAA", 101.0),
+        (" bbb ", 200.0),
+    ]


### PR DESCRIPTION
## Summary
- Reduce the paper engine polling sleep granularity so dashboard quit responds promptly.
- Preserve the same 10-second polling interval while checking the stop flag every 0.2 seconds.
- Dedupe duplicate stock_prices rows by symbol in the market-data loader so TUI market panels show distinct symbols instead of repeated rows.
- Dedupe direct TUI screener stock queries and avoid launching the Signals worker twice on tab switch.
- Add nontechnical launchers: macOS .app, macOS .command, Windows .bat, and a shared bootstrapper that creates .venv, installs deps, downloads the bundled DB if missing, runs preflight, and starts the TUI.

## Validation
- sh -n Launch Quant Terminal.command
- sh -n Nepse Quant Terminal.app/Contents/MacOS/Nepse Quant Terminal
- plutil -lint Nepse Quant Terminal.app/Contents/Info.plist
- python3 -m py_compile scripts/launch/bootstrap.py
- python3 -m py_compile apps/classic/dashboard.py apps/tui/dashboard_tui.py backend/trading/tui_trading_engine.py
- python3 -m py_compile apps/tui/dashboard_tui.py backend/trading/tui_trading_engine.py backend/trading/paper_execution.py backend/agents/runtime_config.py
- python3 -m scripts.ops.windows_preflight
- pytest tests/unit/test_easy_launch.py -q
- pytest tests/unit/test_dashboard_market_data.py -q
- pytest tests/unit/test_dashboard_tui_market_helpers.py tests/unit/test_dashboard_market_data.py -q
- pytest tests/unit/test_paper_execution_service.py tests/unit/test_agent_runtime_config.py tests/unit/test_dashboard_issue8.py tests/unit/test_strategy_backtest_registry.py -q
- pytest tests/unit -q
- Launched python3 -m apps.tui.dashboard_tui, entered paper mode, confirmed market panels rendered, and confirmed q exits cleanly with code 0
- Captured Textual-native screenshots for all tabs at verification_artifacts/tui_tabs_final_contact_sheet.png