### PR TITLE
Add easy launch app wrappers

### DIFF
--- a/Launch Quant Terminal.bat
+++ b/Launch Quant Terminal.bat
@@ -1,0 +1,35 @@
+@echo off
+setlocal
+
+cd /d "%~dp0"
+
+py -3.12 --version >nul 2>&1
+if %ERRORLEVEL% EQU 0 (
+    set "PYTHON_CMD=py -3.12"
+) else (
+    python --version >nul 2>&1
+    if %ERRORLEVEL% EQU 0 (
+        set "PYTHON_CMD=python"
+    ) else (
+        echo Python was not found.
+        echo Install Python 3.12 from https://www.python.org/downloads/ and launch again.
+        echo Make sure "Add python.exe to PATH" is selected during install.
+        echo.
+        pause
+        exit /b 1
+    )
+)
+
+%PYTHON_CMD% scripts\launch\bootstrap.py
+set "STATUS=%ERRORLEVEL%"
+
+echo.
+if not "%STATUS%"=="0" (
+    echo NEPSE Quant Terminal exited with status %STATUS%.
+    echo Read the message above, fix the issue, then launch again.
+) else (
+    echo NEPSE Quant Terminal closed.
+)
+echo.
+pause
+exit /b %STATUS%

--- a/Launch Quant Terminal.command
+++ b/Launch Quant Terminal.command
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -u
+
+REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+cd "$REPO_ROOT" || exit 1
+
+if command -v python3.12 >/dev/null 2>&1; then
+    PYTHON_BIN=python3.12
+elif command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN=python3
+else
+    echo "Python was not found."
+    echo "Install Python 3.12 from https://www.python.org/downloads/ and launch again."
+    echo
+    printf "Press Enter to close..."
+    read -r _
+    exit 1
+fi
+
+"$PYTHON_BIN" scripts/launch/bootstrap.py
+STATUS=$?
+
+echo
+if [ "$STATUS" -ne 0 ]; then
+    echo "NEPSE Quant Terminal exited with status $STATUS."
+    echo "Read the message above, fix the issue, then launch again."
+else
+    echo "NEPSE Quant Terminal closed."
+fi
+echo
+printf "Press Enter to close this window..."
+read -r _
+exit "$STATUS"

--- a/Nepse Quant Terminal.app/Contents/Info.plist
+++ b/Nepse Quant Terminal.app/Contents/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleDisplayName</key>
+  <string>Nepse Quant Terminal</string>
+  <key>CFBundleExecutable</key>
+  <string>Nepse Quant Terminal</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.nlethetech.nepsequantterminal</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>Nepse Quant Terminal</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>10.15</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+</dict>
+</plist>

--- a/Nepse Quant Terminal.app/Contents/MacOS/Nepse Quant Terminal
+++ b/Nepse Quant Terminal.app/Contents/MacOS/Nepse Quant Terminal
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -u
+
+MACOS_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$MACOS_DIR/../../.." && pwd)
+
+if [ ! -f "$REPO_ROOT/Launch Quant Terminal.command" ]; then
+    osascript -e 'display dialog "Keep Nepse Quant Terminal.app inside the nepse-quant-terminal repo folder, then open it again." buttons {"OK"} default button "OK" with title "NEPSE Quant Terminal"'
+    exit 1
+fi
+
+escaped_repo=$(printf '%s' "$REPO_ROOT" | sed 's/\\/\\\\/g; s/"/\\"/g')
+
+osascript <<APPLESCRIPT
+set repoPath to "$escaped_repo"
+tell application "Terminal"
+    activate
+    do script "cd " & quoted form of repoPath & " && sh " & quoted form of (repoPath & "/Launch Quant Terminal.command")
+end tell
+APPLESCRIPT

--- a/README.md
+++ b/README.md
@@ -207,6 +207,17 @@ Register it in the `SIGNAL_MAP` dict inside `run_backtest()` and add `"my_signal
 
 ## Setup
 
+### Easy launch for nontechnical users
+
+After downloading or cloning the repo, use the double-click launcher for your OS:
+
+- macOS: `Nepse Quant Terminal.app` or `Launch Quant Terminal.command`
+- Windows: `Launch Quant Terminal.bat`
+
+The launcher creates `.venv`, installs dependencies, downloads the bundled market database if missing, runs preflight, and starts the TUI.
+
+See [`docs/EASY_LAUNCH.md`](docs/EASY_LAUNCH.md) for troubleshooting notes and macOS security prompt handling.
+
 ### Requirements
 
 - Python 3.10–3.13 (recommended: 3.12) — Python 3.14+ is **not yet supported** (numba and the nepse package both cap at `<3.14`)

--- a/docs/EASY_LAUNCH.md
+++ b/docs/EASY_LAUNCH.md
@@ -1,0 +1,48 @@
+# Easy Launch
+
+NEPSE Quant Terminal can be launched without manually creating a virtual environment.
+
+## macOS
+
+Double-click:
+
+- `Nepse Quant Terminal.app`, or
+- `Launch Quant Terminal.command`
+
+The launcher opens Terminal, creates `.venv` if needed, installs `requirements.txt`, downloads the bundled market database if missing, runs preflight, then starts the TUI.
+
+Keep `Nepse Quant Terminal.app` inside the repo folder. It is a lightweight launcher that uses the files beside it; do not drag it into `/Applications` by itself.
+
+If macOS blocks the app because it was downloaded from the internet:
+
+1. Right-click `Nepse Quant Terminal.app`
+2. Click **Open**
+3. Confirm **Open**
+
+Python 3.12 is recommended. Python 3.10 through 3.13 is supported.
+
+## Windows
+
+Double-click:
+
+- `Launch Quant Terminal.bat`
+
+The launcher creates `.venv`, installs dependencies, downloads the bundled market database if missing, runs preflight, then starts the TUI.
+
+Python 3.12 is recommended. During Python install, select **Add python.exe to PATH**.
+
+## What Gets Created
+
+The launcher writes only local runtime files:
+
+- `.venv/`
+- `data/nepse_market_data.db` if missing
+- `data/runtime/`
+
+These are local machine files and should not be committed.
+
+## Troubleshooting
+
+- If dependency installation fails, install Git and launch again. The NEPSE package is installed from GitHub.
+- If the dashboard opens but data is stale, run `python setup_data.py --scrape --days 90` from the activated environment or use the normal scraper workflow.
+- If the terminal closes immediately, run the `.command` or `.bat` launcher directly so the error remains visible.

--- a/scripts/launch/__init__.py
+++ b/scripts/launch/__init__.py
@@ -1,0 +1,1 @@
+"""User-facing launch helpers for NEPSE Quant Terminal."""

--- a/scripts/launch/bootstrap.py
+++ b/scripts/launch/bootstrap.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Create/update the local environment and launch the Textual dashboard."""
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+MIN_PYTHON = (3, 10)
+MAX_PYTHON_EXCLUSIVE = (3, 14)
+VENV_DIRNAME = ".venv"
+REQUIREMENTS_STAMP = ".nepse_quant_requirements.sha256"
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def is_supported_python(version: Sequence[int] | None = None) -> bool:
+    parts = tuple(version or sys.version_info[:3])
+    return MIN_PYTHON <= parts[:2] < MAX_PYTHON_EXCLUSIVE
+
+
+def requirements_hash(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def venv_python(root: Path) -> Path:
+    if os.name == "nt":
+        return root / VENV_DIRNAME / "Scripts" / "python.exe"
+    return root / VENV_DIRNAME / "bin" / "python"
+
+
+def run(cmd: Sequence[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess:
+    print(f"\n$ {' '.join(str(part) for part in cmd)}", flush=True)
+    return subprocess.run([str(part) for part in cmd], cwd=str(cwd), check=check)
+
+
+def ensure_supported_python() -> None:
+    if is_supported_python():
+        return
+    current = ".".join(map(str, sys.version_info[:3]))
+    raise SystemExit(
+        f"Python {current} is not supported. Install Python 3.10 through 3.13, "
+        "then launch again. Python 3.12 is recommended."
+    )
+
+
+def ensure_virtualenv(root: Path) -> Path:
+    python = venv_python(root)
+    if python.exists():
+        return python
+    print(f"Creating local Python environment at {root / VENV_DIRNAME}...")
+    run([sys.executable, "-m", "venv", root / VENV_DIRNAME], cwd=root)
+    return python
+
+
+def ensure_requirements(root: Path, python: Path) -> None:
+    requirements = root / "requirements.txt"
+    stamp = root / VENV_DIRNAME / REQUIREMENTS_STAMP
+    current_hash = requirements_hash(requirements)
+    if stamp.exists() and stamp.read_text(encoding="utf-8").strip() == current_hash:
+        print("Python dependencies are already installed.")
+        return
+
+    print("Installing Python dependencies. First launch can take a few minutes...")
+    run([python, "-m", "pip", "install", "-U", "pip"], cwd=root)
+    try:
+        run([python, "-m", "pip", "install", "-r", requirements], cwd=root)
+    except subprocess.CalledProcessError as exc:
+        print(
+            "\nDependency install failed. Make sure Git is installed and available on PATH, "
+            "then launch again."
+        )
+        raise SystemExit(exc.returncode) from exc
+    stamp.write_text(current_hash + "\n", encoding="utf-8")
+
+
+def ensure_database(root: Path, python: Path) -> None:
+    probe = (
+        "from pathlib import Path\n"
+        "from backend.quant_pro.database import get_db_path\n"
+        "path = Path(get_db_path())\n"
+        "print(path)\n"
+        "raise SystemExit(0 if path.exists() else 2)\n"
+    )
+    result = run([python, "-c", probe], cwd=root, check=False)
+    if result.returncode == 0:
+        print("Market database found.")
+        return
+
+    print("Market database is missing. Downloading the bundled database...")
+    run([python, "setup_data.py"], cwd=root)
+
+
+def run_preflight(root: Path, python: Path) -> None:
+    print("Running launch preflight...")
+    try:
+        run([python, "-m", "scripts.ops.windows_preflight"], cwd=root)
+    except subprocess.CalledProcessError as exc:
+        print("\nPreflight failed. Fix the issue above, then launch again.")
+        raise SystemExit(exc.returncode) from exc
+
+
+def launch_tui(root: Path, python: Path) -> int:
+    env = os.environ.copy()
+    env.setdefault("PYTHONUTF8", "1")
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    env.setdefault("NEPSE_LAUNCHED_FROM_HELPER", platform.system())
+    print("\nLaunching NEPSE Quant Terminal...\n")
+    return subprocess.run(
+        [str(python), "-m", "apps.tui.dashboard_tui"],
+        cwd=str(root),
+        env=env,
+        check=False,
+    ).returncode
+
+
+def main() -> int:
+    root = repo_root()
+    os.chdir(root)
+    ensure_supported_python()
+    python = ensure_virtualenv(root)
+    ensure_requirements(root, python)
+    ensure_database(root, python)
+    run_preflight(root, python)
+    return launch_tui(root, python)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_easy_launch.py
+++ b/tests/unit/test_easy_launch.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from scripts.launch import bootstrap
+
+
+def test_supported_python_range():
+    assert bootstrap.is_supported_python((3, 10, 0))
+    assert bootstrap.is_supported_python((3, 12, 4))
+    assert bootstrap.is_supported_python((3, 13, 9))
+    assert not bootstrap.is_supported_python((3, 9, 18))
+    assert not bootstrap.is_supported_python((3, 14, 0))
+
+
+def test_requirements_hash_changes_with_file_content(tmp_path):
+    path = tmp_path / "requirements.txt"
+    path.write_text("textual\n", encoding="utf-8")
+    first = bootstrap.requirements_hash(path)
+    path.write_text("textual\nrich\n", encoding="utf-8")
+    second = bootstrap.requirements_hash(path)
+
+    assert first != second
+
+
+def test_venv_python_path_is_platform_specific(monkeypatch, tmp_path):
+    monkeypatch.setattr(bootstrap.os, "name", "nt")
+    assert bootstrap.venv_python(tmp_path) == tmp_path / ".venv" / "Scripts" / "python.exe"
+
+    monkeypatch.setattr(bootstrap.os, "name", "posix")
+    assert bootstrap.venv_python(tmp_path) == tmp_path / ".venv" / "bin" / "python"


### PR DESCRIPTION
## Summary
- Add a macOS .app wrapper that opens Terminal and starts the TUI from the repo folder.
- Add double-click macOS .command and Windows .bat launchers.
- Add a shared bootstrapper that creates .venv, installs requirements when they change, downloads the bundled market database if missing, runs preflight, and launches apps.tui.dashboard_tui.
- Document the nontechnical launch path in README and docs/EASY_LAUNCH.md.

## Validation
- sh -n Launch Quant Terminal.command
- sh -n Nepse Quant Terminal.app/Contents/MacOS/Nepse Quant Terminal
- plutil -lint Nepse Quant Terminal.app/Contents/Info.plist
- python3 -m py_compile scripts/launch/bootstrap.py
- pytest tests/unit/test_easy_launch.py -q
- pytest tests/unit -q