### PR TITLE
Block suspended symbols from paper autopilot

### DIFF
--- a/backend/backtesting/simple_backtest.py
+++ b/backend/backtesting/simple_backtest.py
@@ -38,7 +38,7 @@ from backend.quant_pro.alpha_practical import (
 from backend.quant_pro.sectors import SECTOR_GROUPS
 from backend.quant_pro.database import get_db_path
 from backend.quant_pro.event_layer import load_event_adjustment_context
-from backend.quant_pro.signal_ranking import rank_signal_candidates
+from backend.quant_pro.signal_ranking import is_tradeable_signal_symbol, rank_signal_candidates
 
 # Agent 3 signal imports (Citadel upgrade)
 from backend.quant_pro.disposition import generate_cgo_signals_at_date
@@ -1195,9 +1195,9 @@ def compute_liquid_universe(
     This should be applied BEFORE signal computation to reduce noise
     from illiquid names in the ranking.
     """
-    # Exclude non-tradable symbols (market index, sector indices)
+    # Exclude non-tradable symbols (market index, sector indices, suspended names)
     all_symbols = prices_df["symbol"].unique()
-    symbols = [s for s in all_symbols if s != "NEPSE" and not str(s).startswith("SECTOR::")]
+    symbols = [s for s in all_symbols if is_tradeable_signal_symbol(s)]
     turnover_map = {}
 
     for symbol in symbols:
@@ -1448,8 +1448,8 @@ def generate_52wk_high_signals_at_date(
     symbols = liquid_symbols if liquid_symbols else prices_df["symbol"].unique()
 
     for symbol in symbols:
-        # Skip index entries
-        if symbol == "NEPSE" or str(symbol).startswith("SECTOR::"):
+        # Skip index entries and suspended/non-tradeable symbols.
+        if not is_tradeable_signal_symbol(symbol):
             continue
 
         sym_df = prices_df[
@@ -1540,7 +1540,7 @@ def generate_value_bounce_signals_at_date(
     symbols = liquid_symbols if liquid_symbols else prices_df["symbol"].unique()
 
     for symbol in symbols:
-        if symbol == "NEPSE" or str(symbol).startswith("SECTOR::"):
+        if not is_tradeable_signal_symbol(symbol):
             continue
 
         sym_df = prices_df[
@@ -1665,8 +1665,8 @@ def generate_residual_momentum_signals_at_date(
     residual_scores = {}
 
     for symbol in symbols:
-        # Skip index entries
-        if symbol == "NEPSE" or str(symbol).startswith("SECTOR::"):
+        # Skip index entries and suspended/non-tradeable symbols.
+        if not is_tradeable_signal_symbol(symbol):
             continue
 
         sym_df = prices_df[

--- a/backend/quant_pro/signal_ranking.py
+++ b/backend/quant_pro/signal_ranking.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from collections import defaultdict
 from typing import Any, Callable, Dict, Iterable, List, Optional
 
@@ -11,6 +12,9 @@ SYMBOL_ALIASES: Dict[str, str] = {
     "RHPC": "RIDI",
 }
 
+DEFAULT_BLOCKED_SIGNAL_SYMBOLS = frozenset({"KRBL", "UIC"})
+BLOCKED_SYMBOLS_ENV = "NEPSE_BLOCKED_SYMBOLS"
+
 
 def canonicalize_signal_symbol(symbol: Any) -> str:
     token = str(symbol or "").strip().upper()
@@ -19,15 +23,31 @@ def canonicalize_signal_symbol(symbol: Any) -> str:
     return SYMBOL_ALIASES.get(token, token)
 
 
-def is_tradeable_signal_symbol(symbol: Any) -> bool:
+def blocked_signal_symbols() -> set[str]:
+    symbols = set(DEFAULT_BLOCKED_SIGNAL_SYMBOLS)
+    raw = str(os.environ.get(BLOCKED_SYMBOLS_ENV, "") or "")
+    for token in raw.replace(";", ",").split(","):
+        symbol = canonicalize_signal_symbol(token)
+        if symbol:
+            symbols.add(symbol)
+    return symbols
+
+
+def blocked_signal_symbol_reason(symbol: Any) -> Optional[str]:
     token = canonicalize_signal_symbol(symbol)
     if not token:
-        return False
+        return "empty_symbol"
     if token == "NEPSE":
-        return False
+        return "market_index_not_tradeable"
     if token.startswith("SECTOR::"):
-        return False
-    return True
+        return "sector_index_not_tradeable"
+    if token in blocked_signal_symbols():
+        return "suspended_or_non_tradeable_symbol"
+    return None
+
+
+def is_tradeable_signal_symbol(symbol: Any) -> bool:
+    return blocked_signal_symbol_reason(symbol) is None
 
 
 def _base_signal_score(signal: Dict[str, Any]) -> float:

--- a/backend/trading/paper_execution.py
+++ b/backend/trading/paper_execution.py
@@ -32,6 +32,7 @@ else:
 import pandas as pd
 
 from backend.backtesting.simple_backtest import get_symbol_sector
+from backend.quant_pro.signal_ranking import blocked_signal_symbol_reason, canonicalize_signal_symbol
 from backend.quant_pro.nepse_calendar import current_nepal_datetime
 from backend.quant_pro.paths import ensure_dir, get_runtime_dir
 from backend.trading.live_trader import (
@@ -456,6 +457,9 @@ class PaperExecutionService:
 
         if state.get("manual_halt"):
             return {"ok": False, "reason": "manual_halt"}
+        symbol_block = blocked_signal_symbol_reason(symbol)
+        if symbol_block:
+            return {"ok": False, "reason": "blocked_symbol", "detail": symbol_block, "symbol": symbol}
         if quote_age_seconds is not None and quote_age_seconds > self.max_quote_age_seconds:
             return {"ok": False, "reason": "stale_quote", "quote_age_seconds": quote_age_seconds}
         if quantity <= 0 or limit_price <= 0:
@@ -559,9 +563,28 @@ class PaperExecutionService:
             return PaperExecutionResult(False, "rejected", f"Unknown account {account_id}")
 
         action_text = str(action or "").upper()
-        sym = str(symbol or "").upper()
+        sym = canonicalize_signal_symbol(symbol)
         qty = int(quantity)
         price = float(limit_price)
+        risk = self._risk_check(action=action_text, symbol=sym, quantity=qty, limit_price=price)
+        if not risk.get("ok"):
+            rejected = self._visible_rejection(
+                action=action_text,
+                symbol=sym,
+                quantity=qty,
+                limit_price=price,
+                slippage_pct=slippage_pct,
+                source=source,
+                reason=reason,
+                strategy_id=str(strategy_id or self.strategy_id),
+                run_id=run_id,
+                risk_result=risk,
+            )
+            message = str(risk.get("reason") or "rejected")
+            if message == "blocked_symbol":
+                message = f"Blocked symbol {sym}: {risk.get('detail') or 'non_tradeable'}"
+            return PaperExecutionResult(False, "rejected", message, rejected, rejected_orders=[rejected], risk_result=risk)
+
         orders = self._load_orders()
         duplicate = any(
             order.status == "OPEN" and order.action == action_text and order.symbol == sym
@@ -582,22 +605,6 @@ class PaperExecutionService:
                 risk_result=risk,
             )
             return PaperExecutionResult(False, "rejected", "Duplicate open order", rejected, rejected_orders=[rejected], risk_result=risk)
-
-        risk = self._risk_check(action=action_text, symbol=sym, quantity=qty, limit_price=price)
-        if not risk.get("ok"):
-            rejected = self._visible_rejection(
-                action=action_text,
-                symbol=sym,
-                quantity=qty,
-                limit_price=price,
-                slippage_pct=slippage_pct,
-                source=source,
-                reason=reason,
-                strategy_id=str(strategy_id or self.strategy_id),
-                run_id=run_id,
-                risk_result=risk,
-            )
-            return PaperExecutionResult(False, "rejected", str(risk.get("reason") or "rejected"), rejected, rejected_orders=[rejected], risk_result=risk)
 
         ts = _now_stamp()
         order = PaperOrder(

--- a/backend/trading/tui_trading_engine.py
+++ b/backend/trading/tui_trading_engine.py
@@ -45,6 +45,7 @@ from backend.quant_pro.config import (
 )
 from backend.quant_pro.database import get_db_path
 from backend.quant_pro.nepse_calendar import is_trading_day
+from backend.quant_pro.signal_ranking import blocked_signal_symbol_reason, canonicalize_signal_symbol
 from backend.backtesting.simple_backtest import get_symbol_sector, load_all_prices
 from backend.trading.paper_execution import PaperExecutionService
 from validation.transaction_costs import TransactionCostModel as NepseFees
@@ -386,6 +387,18 @@ class TUITradingEngine:
                 use_regime_filter=True,
             )
             self.regime = regime
+            blocked = [
+                sig for sig in signals
+                if blocked_signal_symbol_reason(sig.get("symbol"))
+            ]
+            for sig in blocked:
+                symbol = canonicalize_signal_symbol(sig.get("symbol"))
+                self._log(f"BLOCK {symbol}: {blocked_signal_symbol_reason(symbol)}")
+            signals = [
+                {**sig, "symbol": canonicalize_signal_symbol(sig.get("symbol"))}
+                for sig in signals
+                if not blocked_signal_symbol_reason(sig.get("symbol"))
+            ]
             self.signals_today = signals
             self._active_run_id = f"{now_nst().strftime('%Y%m%d')}-{self.account_id}-{uuid.uuid4().hex[:8]}"
             self._paper_execution.start_strategy_manifest(
@@ -399,7 +412,7 @@ class TUITradingEngine:
                 },
                 signals=signals,
             )
-            self._log(f"{len(signals)} raw signals, regime={regime}")
+            self._log(f"{len(signals)} tradeable signals, regime={regime}")
         except Exception as e:
             self._log(f"Signal generation failed: {e}")
             self.signals_today = []
@@ -428,8 +441,17 @@ class TUITradingEngine:
             self._log("No position slots available")
             return
 
+        tradeable_signals: List[dict] = []
+        for sig in signals:
+            sym = canonicalize_signal_symbol(sig.get("symbol"))
+            block_reason = blocked_signal_symbol_reason(sym)
+            if block_reason:
+                self._log(f"BLOCK {sym}: {block_reason}")
+                continue
+            tradeable_signals.append({**sig, "symbol": sym})
+
         # Fetch LTPs for all candidate symbols
-        candidate_syms = [s["symbol"] for s in signals if s["symbol"] not in self.positions]
+        candidate_syms = [s["symbol"] for s in tradeable_signals if s["symbol"] not in self.positions]
         if not candidate_syms:
             return
 
@@ -438,7 +460,7 @@ class TUITradingEngine:
         per_position = self._compute_deployable_capital() / self.max_positions
         bought = 0
 
-        for sig in signals:
+        for sig in tradeable_signals:
             if bought >= available_slots:
                 break
 

--- a/tests/unit/test_paper_execution_service.py
+++ b/tests/unit/test_paper_execution_service.py
@@ -68,6 +68,22 @@ def test_paper_execution_rejects_duplicate_open_order_visibly(tmp_path, monkeypa
     assert any(row["status"] == "REJECTED" for row in state["order_history"])
 
 
+def test_paper_execution_rejects_suspended_symbol_visibly(tmp_path, monkeypatch):
+    monkeypatch.setattr("backend.trading.paper_execution.current_nepal_datetime", _fixed_nst)
+    service = PaperExecutionService("account_1", account_dir=tmp_path, max_order_notional=500_000)
+
+    result = service.submit_order("account_1", "BUY", "UIC", 100, 100.0, "strategy_paper", "volume")
+    state = service.get_account_execution_state("account_1")
+
+    assert not result.ok
+    assert result.risk_result["reason"] == "blocked_symbol"
+    assert result.risk_result["detail"] == "suspended_or_non_tradeable_symbol"
+    assert "Blocked symbol UIC" in result.message
+    assert not state["open_orders"]
+    assert state["order_history"][0]["status"] == "REJECTED"
+    assert state["order_history"][0]["symbol"] == "UIC"
+
+
 def test_paper_execution_migrates_legacy_tui_trade_log_without_duplicates(tmp_path):
     pd.DataFrame(columns=PORTFOLIO_COLS).to_csv(tmp_path / "paper_portfolio.csv", index=False)
     legacy_trade = pd.DataFrame(
@@ -127,6 +143,36 @@ def test_tui_trading_engine_autopilot_writes_canonical_account_ledger(tmp_path, 
     assert trades.loc[0, "Reason"] == "volume"
     assert (tmp_path / "strategy_runs" / "run-1.json").exists()
     assert any("BUY NABIL" in event for event in events)
+
+
+def test_tui_trading_engine_blocks_suspended_autopilot_signal(tmp_path, monkeypatch):
+    monkeypatch.setattr("backend.trading.paper_execution.current_nepal_datetime", _fixed_nst)
+    monkeypatch.setattr("backend.trading.tui_trading_engine.now_nst", _fixed_nst)
+    monkeypatch.setattr("backend.trading.tui_trading_engine.fetch_prices_for_symbols", lambda symbols: {sym: 100.0 for sym in symbols})
+
+    events = []
+    engine = TUITradingEngine(
+        capital=1_000_000,
+        signal_types=["volume"],
+        max_positions=5,
+        holding_days=40,
+        sector_limit=0.35,
+        portfolio_file=tmp_path / "paper_portfolio.csv",
+        trade_log_file=tmp_path / "paper_trade_log.csv",
+        nav_log_file=tmp_path / "paper_nav_log.csv",
+        state_file=tmp_path / "paper_state.json",
+        account_id="account_1",
+        strategy_id="s1",
+        strategy_config={"id": "s1"},
+        on_activity=events.append,
+    )
+
+    engine._active_run_id = "run-1"
+    engine._execute_buys([{"symbol": "KRBL", "signal_type": "volume", "agent_reason": "", "score": 0.9}])
+
+    assert pd.read_csv(tmp_path / "paper_portfolio.csv").empty
+    assert pd.read_csv(tmp_path / "paper_trade_log.csv").empty
+    assert any("BLOCK KRBL: suspended_or_non_tradeable_symbol" in event for event in events)
 
 
 def test_tui_trading_engine_passes_risk_thresholds_to_exit_check(tmp_path, monkeypatch):

--- a/tests/unit/test_signal_ranking.py
+++ b/tests/unit/test_signal_ranking.py
@@ -3,7 +3,28 @@
 from __future__ import annotations
 
 from backend.quant_pro.event_layer import EventAdjustmentContext
-from backend.quant_pro.signal_ranking import rank_signal_candidates
+from backend.quant_pro.signal_ranking import (
+    blocked_signal_symbol_reason,
+    is_tradeable_signal_symbol,
+    rank_signal_candidates,
+)
+
+
+def test_tradeable_policy_blocks_indexes_and_suspended_symbols():
+    assert not is_tradeable_signal_symbol("NEPSE")
+    assert not is_tradeable_signal_symbol("SECTOR::BANKING")
+    assert not is_tradeable_signal_symbol("KRBL")
+    assert not is_tradeable_signal_symbol("UIC")
+    assert blocked_signal_symbol_reason("KRBL") == "suspended_or_non_tradeable_symbol"
+    assert is_tradeable_signal_symbol("NABIL")
+
+
+def test_tradeable_policy_honors_env_blocklist(monkeypatch):
+    monkeypatch.setenv("NEPSE_BLOCKED_SYMBOLS", "AAA, BBB")
+
+    assert not is_tradeable_signal_symbol("AAA")
+    assert not is_tradeable_signal_symbol("BBB")
+    assert blocked_signal_symbol_reason("AAA") == "suspended_or_non_tradeable_symbol"
 
 
 def test_rank_signal_candidates_merges_duplicate_symbol_support():


### PR DESCRIPTION
## Summary
- block suspended/non-tradeable symbols KRBL and UIC in the shared signal policy
- apply the policy across signal ranking, backtest universe filters, TUI autopilot buys, and PaperExecutionService risk checks
- make rejected suspended-symbol paper orders visible in order history with a risk reason

## Tests
- python3 -m py_compile backend/quant_pro/signal_ranking.py backend/backtesting/simple_backtest.py backend/trading/paper_execution.py backend/trading/tui_trading_engine.py
- python3 -m pytest tests/unit/test_signal_ranking.py tests/unit/test_paper_execution_service.py -q
- python3 -m pytest tests/unit -q

Fixes #17