### PR TITLE
Show saved backtest results in the TUI

### DIFF
--- a/apps/tui/dashboard_tui.py
+++ b/apps/tui/dashboard_tui.py
@@ -6690,17 +6690,23 @@ class NepseDashboard(App):
             except Exception as exc:
                 self._set_status(f"Strategy backtest failed: {exc}")
         elif bid == "strategy-btn-chart":
-            result = getattr(self, "_strategy_backtest_result", None)
+            selected = self._selected_strategy_payload()
+            selected_id = str((selected or {}).get("id") or getattr(self, "_selected_strategy_id", "") or "").strip()
+            result = dict(getattr(self, "_strategy_backtest_result", {}) or {})
+            if result and str((result.get("strategy") or {}).get("id") or "") != selected_id:
+                result = {}
+            if not result and selected_id:
+                result = dict(strategy_registry.load_strategy_backtest_result(selected_id) or {})
             if not result:
                 self._set_status("Run a backtest first — no result to chart")
             else:
                 try:
                     from validation.quick_chart import generate_quick_chart
                     from backend.quant_pro.database import get_db_path as _get_db_path
-                    selected = self._selected_strategy_payload()
                     name   = str((selected or {}).get("name") or "Strategy")
-                    start  = str(self.query_one("#strategy-inp-backtest-start", Input).value or "").strip()
-                    end    = str(self.query_one("#strategy-inp-backtest-end", Input).value or "").strip()
+                    window = dict(result.get("window") or {})
+                    start  = str(window.get("start") or self.query_one("#strategy-inp-backtest-start", Input).value or "").strip()
+                    end    = str(window.get("end") or self.query_one("#strategy-inp-backtest-end", Input).value or "").strip()
                     path   = generate_quick_chart(
                         result,
                         strategy_name=name,
@@ -7401,6 +7407,11 @@ class NepseDashboard(App):
         except Exception:
             return
         result = dict(getattr(self, "_strategy_backtest_result", {}) or {})
+        selected_id = str(getattr(self, "_selected_strategy_id", "") or "").strip()
+        if result and str((result.get("strategy") or {}).get("id") or "") != selected_id:
+            result = {}
+        if not result and selected_id:
+            result = dict(strategy_registry.load_strategy_backtest_result(selected_id) or {})
         if not result:
             widget.update(
                 Text.from_markup(
@@ -7418,9 +7429,9 @@ class NepseDashboard(App):
                 f"[bold {WHITE}]Strategy[/] {summary.get('total_return_pct', 0.0):+.2f}%   "
                 f"[bold {WHITE}]NEPSE[/] {float(nepse.get('return_pct') or 0.0):+.2f}%   "
                 f"[bold {WHITE}]Alpha[/] {float(summary.get('vs_nepse_pct_points') or 0.0):+.2f}pp   "
-                f"[bold {WHITE}]Sharpe[/] {float(summary.get('sharpe_ratio') or 0.0):.2f}   "
+                f"[bold {WHITE}]Sharpe[/] {float(summary.get('sharpe_ratio', summary.get('sharpe')) or 0.0):.2f}   "
                 f"[bold {WHITE}]MaxDD[/] {float(summary.get('max_drawdown_pct') or 0.0):+.2f}%   "
-                f"[bold {WHITE}]Trades[/] {int(summary.get('trade_count') or 0)}\n"
+                f"[bold {WHITE}]Trades[/] {int(summary.get('trade_count', summary.get('total_trades')) or 0)}\n"
                 f"[#8aa0b5]Saved[/] data/strategy_registry/backtests/{str(result.get('strategy', {}).get('id') or 'strategy')}_latest.json"
             )
         )

--- a/backend/trading/strategy_registry.py
+++ b/backend/trading/strategy_registry.py
@@ -31,6 +31,14 @@ def _json_write(path: Path, payload: Dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
 
 
+def _json_read(path: Path) -> Optional[Dict[str, Any]]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
 def _baseline_c31_config() -> Dict[str, Any]:
     config = copy.deepcopy(LONG_TERM_CONFIG)
     config.setdefault("use_trailing_stop", True)
@@ -200,11 +208,15 @@ def _summarize_backtest_result(strategy_id: str, description: str, result: Any) 
         "annualized_return_pct": _pct(getattr(result, "annualized_return", 0.0)),
         "volatility_pct": _pct(getattr(result, "volatility", 0.0)),
         "sharpe": round(float(getattr(result, "sharpe_ratio", 0.0) or 0.0), 4),
+        "sharpe_ratio": round(float(getattr(result, "sharpe_ratio", 0.0) or 0.0), 4),
         "sortino": round(float(getattr(result, "sortino_ratio", 0.0) or 0.0), 4),
+        "sortino_ratio": round(float(getattr(result, "sortino_ratio", 0.0) or 0.0), 4),
         "max_drawdown_pct": _pct(getattr(result, "max_drawdown", 0.0)),
         "max_drawdown_duration": int(getattr(result, "max_drawdown_duration", 0) or 0),
         "calmar": round(float(getattr(result, "calmar_ratio", 0.0) or 0.0), 4),
+        "calmar_ratio": round(float(getattr(result, "calmar_ratio", 0.0) or 0.0), 4),
         "total_trades": int(getattr(result, "total_trades", 0) or 0),
+        "trade_count": int(getattr(result, "total_trades", 0) or 0),
         "win_rate_pct": _pct(getattr(result, "win_rate", 0.0)),
         "avg_win_pct": _pct(getattr(result, "avg_win", 0.0)),
         "avg_loss_pct": _pct(getattr(result, "avg_loss", 0.0)),
@@ -296,24 +308,74 @@ def run_strategy_backtest(strategy: Dict[str, Any], *, start_date: str, end_date
 
 
 def load_strategy_comparison_snapshot() -> Optional[Dict[str, Any]]:
-    if not COMPARISON_LATEST_JSON.exists():
+    return _json_read(COMPARISON_LATEST_JSON) if COMPARISON_LATEST_JSON.exists() else None
+
+
+def strategy_backtest_path(strategy_id: str) -> Path:
+    sid = str(strategy_id or "").strip()
+    return BACKTEST_RESULTS_DIR / f"{sid}_latest.json"
+
+
+def load_strategy_backtest_result(strategy_id: str) -> Optional[Dict[str, Any]]:
+    sid = str(strategy_id or "").strip()
+    if not sid:
         return None
-    try:
-        payload = json.loads(COMPARISON_LATEST_JSON.read_text(encoding="utf-8"))
-    except Exception:
+    path = strategy_backtest_path(sid)
+    payload = _json_read(path) if path.exists() else None
+    if not payload:
         return None
-    return payload if isinstance(payload, dict) else None
+    strategy = dict(payload.get("strategy") or {})
+    if str(strategy.get("id") or sid) != sid:
+        return None
+    return payload
+
+
+def _normalize_metrics(metrics: Dict[str, Any], *, window: Dict[str, Any], nepse: Dict[str, Any]) -> Dict[str, Any]:
+    row = dict(metrics or {})
+    if "sharpe_ratio" not in row and "sharpe" in row:
+        row["sharpe_ratio"] = row.get("sharpe")
+    if "sharpe" not in row and "sharpe_ratio" in row:
+        row["sharpe"] = row.get("sharpe_ratio")
+    if "sortino_ratio" not in row and "sortino" in row:
+        row["sortino_ratio"] = row.get("sortino")
+    if "sortino" not in row and "sortino_ratio" in row:
+        row["sortino"] = row.get("sortino_ratio")
+    if "calmar_ratio" not in row and "calmar" in row:
+        row["calmar_ratio"] = row.get("calmar")
+    if "calmar" not in row and "calmar_ratio" in row:
+        row["calmar"] = row.get("calmar_ratio")
+    if "trade_count" not in row and "total_trades" in row:
+        row["trade_count"] = row.get("total_trades")
+    if "total_trades" not in row and "trade_count" in row:
+        row["total_trades"] = row.get("trade_count")
+    row["window"] = dict(window or {})
+    row["nepse"] = dict(nepse or {})
+    if "vs_nepse_pct_points" not in row:
+        row["vs_nepse_pct_points"] = round(
+            float(row.get("total_return_pct") or 0.0) - float((row.get("nepse") or {}).get("return_pct") or 0.0),
+            4,
+        )
+    return row
 
 
 def comparison_metrics_for_strategy(strategy_id: str) -> Optional[Dict[str, Any]]:
+    latest = load_strategy_backtest_result(strategy_id)
+    if latest:
+        return _normalize_metrics(
+            dict(latest.get("summary") or {}),
+            window=dict(latest.get("window") or {}),
+            nepse=dict(latest.get("nepse") or {}),
+        )
+
     snapshot = load_strategy_comparison_snapshot()
     if not snapshot:
         return None
     target = str(strategy_id or "").strip()
     for row in list(snapshot.get("strategies") or []):
         if str(row.get("id") or "") == target:
-            metrics = dict(row.get("summary") or {})
-            metrics["window"] = dict(snapshot.get("window") or {})
-            metrics["nepse"] = dict(snapshot.get("nepse") or {})
-            return metrics
+            return _normalize_metrics(
+                dict(row.get("summary") or {}),
+                window=dict(snapshot.get("window") or {}),
+                nepse=dict(snapshot.get("nepse") or {}),
+            )
     return None

--- a/tests/unit/test_strategy_backtest_registry.py
+++ b/tests/unit/test_strategy_backtest_registry.py
@@ -75,9 +75,20 @@ def test_run_strategy_backtest_does_not_require_private_temp_runner(monkeypatch,
     )
 
     assert payload["summary"]["total_return_pct"] == 10.0
+    assert payload["summary"]["sharpe_ratio"] == payload["summary"]["sharpe"]
+    assert payload["summary"]["trade_count"] == payload["summary"]["total_trades"]
     assert payload["summary"]["vs_nepse_pct_points"] == 5.0
     assert payload["summary"]["daily_nav"][-1] == ["2026-01-05", 1100.0]
     assert (tmp_path / "demo_latest.json").exists()
+
+    latest = strategy_registry.load_strategy_backtest_result("demo")
+    assert latest is not None
+    metrics = strategy_registry.comparison_metrics_for_strategy("demo")
+    assert metrics is not None
+    assert metrics["total_return_pct"] == 10.0
+    assert metrics["vs_nepse_pct_points"] == 5.0
+    assert metrics["trade_count"] == metrics["total_trades"]
+    assert metrics["sharpe_ratio"] == metrics["sharpe"]
 
 
 def test_run_backtest_broker_exit_uses_public_db_path(monkeypatch, tmp_path):

--- a/validation/quick_chart.py
+++ b/validation/quick_chart.py
@@ -185,9 +185,9 @@ def generate_quick_chart(
 
     # ── Key metrics ───────────────────────────────────────────────────────────
     strat_ret = float(summary.get("total_return_pct", 0) or 0)
-    sharpe    = float(summary.get("sharpe_ratio", 0) or 0)
+    sharpe    = float(summary.get("sharpe_ratio", summary.get("sharpe")) or 0)
     max_dd    = float(summary.get("max_drawdown_pct", 0) or 0)
-    trades    = int(summary.get("trade_count", 0) or 0)
+    trades    = int(summary.get("trade_count", summary.get("total_trades")) or 0)
     win_rate  = float(summary.get("win_rate_pct", 0) or 0)
     alpha     = strat_ret - nepse_ret_pct
 


### PR DESCRIPTION
## Summary
- show each strategy's latest saved backtest metrics in the Saved Strategies table
- let the Strategy backtest summary panel reload the selected strategy's latest saved result after refresh/restart
- make the Chart button generate from the selected strategy's latest saved result when no in-memory run is present
- normalize backtest metric aliases so Sharpe/trades are consistent across the TUI and chart output

## Tests
- python3 -m pytest tests/unit/test_strategy_backtest_registry.py tests/unit/test_easy_launch.py -q
- python3 -m pytest tests/unit -q