### PR TITLE
Show live backtest progress in the strategy table

### DIFF
--- a/apps/tui/dashboard_tui.py
+++ b/apps/tui/dashboard_tui.py
@@ -3508,6 +3508,7 @@ class NepseDashboard(App):
     _strategies: list[dict] = []
     _selected_strategy_id: str = "default_c5"
     _strategy_backtest_result: dict = {}
+    _strategy_backtest_statuses: dict = {}
     _agent_chat_process: Optional[subprocess.Popen] = None
     _agent_chat_request_id: int = 0
     _agent_chat_stop_requested: bool = False
@@ -7439,6 +7440,63 @@ class NepseDashboard(App):
     def _strategy_saved_metrics(self, strategy_id: str) -> Optional[dict]:
         return strategy_registry.comparison_metrics_for_strategy(strategy_id)
 
+    def _set_strategy_backtest_status(
+        self,
+        strategy_id: str,
+        status: str,
+        message: str = "",
+        progress_pct: Optional[int] = None,
+    ) -> None:
+        sid = str(strategy_id or "").strip()
+        if not sid:
+            return
+        statuses = dict(getattr(self, "_strategy_backtest_statuses", {}) or {})
+        current = dict(statuses.get(sid) or {})
+        if progress_pct is None:
+            progress_pct = current.get("progress_pct")
+        statuses[sid] = {
+            **current,
+            "status": str(status or "").upper(),
+            "message": str(message or ""),
+            "progress_pct": progress_pct,
+        }
+        self._strategy_backtest_statuses = statuses
+        self._populate_strategy_list()
+
+    def _strategy_backtest_status_cell(self, strategy_id: str, metrics: dict) -> Text:
+        sid = str(strategy_id or "").strip()
+        state = dict(((getattr(self, "_strategy_backtest_statuses", {}) or {}).get(sid) or {}))
+        status = str(state.get("status") or "").upper()
+        if status == "RUN":
+            progress = state.get("progress_pct")
+            if progress is not None:
+                return Text(f"{int(progress):>3d}%", style=YELLOW)
+            return Text("RUN", style=YELLOW)
+        if status == "CHART":
+            return Text("CHART", style=YELLOW)
+        if status == "FAIL":
+            return Text("FAIL", style=LOSS_HI)
+        if metrics:
+            return Text("OK", style=GAIN_HI)
+        return Text("—", style=LABEL)
+
+    def _on_strategy_backtest_progress(self, strategy_id: str, payload: dict) -> None:
+        sid = str(strategy_id or "").strip()
+        if not sid:
+            return
+        progress = payload.get("progress_pct")
+        try:
+            progress_int = max(0, min(100, int(progress)))
+        except Exception:
+            progress_int = None
+        message = str(payload.get("message") or "").strip()
+        date_text = str(payload.get("date") or "").strip()
+        if date_text:
+            message = f"{message} | {date_text}".strip(" |")
+        self._set_strategy_backtest_status(sid, "RUN", message, progress_int)
+        if message:
+            self._set_status(f"Backtest progress | {progress_int if progress_int is not None else 0}% | {message}")
+
     def _populate_strategy_list(self) -> None:
         try:
             dt = self.query_one("#dt-strategy-list", DataTable)
@@ -7455,6 +7513,7 @@ class NepseDashboard(App):
             ("DD", "dd", 9),
             ("TRD", "trades", 4),
             ("WR", "win_rate", 6),
+            ("BT", "backtest_status", 7),
         ]:
             dt.add_column(label, key=key, width=width)
         selected_index = 0
@@ -7475,6 +7534,7 @@ class NepseDashboard(App):
                 Text(f"{float(metrics.get('max_drawdown_pct') or 0.0):+.2f}%" if metrics else "—", style=WHITE),
                 Text(str(int(metrics.get("trade_count") or 0)) if metrics else "—", style=WHITE),
                 Text(f"{float(metrics.get('win_rate_pct') or 0.0):.0f}%" if metrics else "—", style=WHITE),
+                self._strategy_backtest_status_cell(sid, metrics),
             )
         if self._strategies:
             try:
@@ -7482,7 +7542,7 @@ class NepseDashboard(App):
             except Exception:
                 pass
         else:
-            dt.add_row(_dim_text("No strategies"), Text(""), Text(""), Text(""), Text(""), Text(""), Text(""), Text(""), Text(""))
+            dt.add_row(_dim_text("No strategies"), Text(""), Text(""), Text(""), Text(""), Text(""), Text(""), Text(""), Text(""), Text(""))
         try:
             row_count = max(1, len(list(getattr(self, "_strategies", []) or [])))
             dt.styles.height = min(max(row_count + 3, 7), 10)
@@ -7623,6 +7683,7 @@ class NepseDashboard(App):
             payload = strategy_registry.load_strategy(strategy_id)
             if not payload:
                 raise ValueError("Strategy not found")
+            self.call_from_thread(self._set_strategy_backtest_status, strategy_id, "RUN")
             self.call_from_thread(self._set_status, f"Backtesting {payload.get('name')}...")
             log_path = PROJECT_ROOT / "data" / "runtime" / "logs" / "strategy_backtest.log"
             log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -7662,6 +7723,11 @@ class NepseDashboard(App):
                     start_date=start_date,
                     end_date=end_date,
                     capital=capital,
+                    progress_callback=lambda progress: self.call_from_thread(
+                        self._on_strategy_backtest_progress,
+                        strategy_id,
+                        dict(progress or {}),
+                    ),
                 )
                 logging.getLogger(__name__).info("Finished strategy backtest id=%s", strategy_id)
             finally:
@@ -7676,6 +7742,7 @@ class NepseDashboard(App):
             summary = dict(result.get("summary") or {})
             nepse   = dict(result.get("nepse") or {})
             self.call_from_thread(self._populate_strategies_tab)
+            self.call_from_thread(self._set_strategy_backtest_status, strategy_id, "CHART")
             strat_ret = float(summary.get("total_return_pct") or 0.0)
             nepse_ret = float(nepse.get("return_pct") or 0.0)
             self.call_from_thread(
@@ -7701,7 +7768,9 @@ class NepseDashboard(App):
                 self._set_status,
                 f"Backtest done | {payload.get('name')} {strat_ret:+.2f}% vs NEPSE {nepse_ret:+.2f}%{chart_note}",
             )
+            self.call_from_thread(self._set_strategy_backtest_status, strategy_id, "OK")
         except Exception as exc:
+            self.call_from_thread(self._set_strategy_backtest_status, strategy_id, "FAIL", str(exc))
             self.call_from_thread(self._set_status, f"Strategy backtest failed: {exc}")
 
     def _start_strategy_backtest(self) -> str:
@@ -7714,7 +7783,9 @@ class NepseDashboard(App):
         if not start or not end:
             raise ValueError("Enter start and end dates")
         capital = float(capital_raw or INITIAL_CAPITAL)
-        self._run_strategy_backtest_async(str(selected.get("id") or ""), start, end, capital)
+        strategy_id = str(selected.get("id") or "")
+        self._set_strategy_backtest_status(strategy_id, "RUN")
+        self._run_strategy_backtest_async(strategy_id, start, end, capital)
         return f"Backtest launched for {selected.get('name')}"
 
     def _profile_runtime_snapshot(self, *, account_dir: Optional[Path] = None) -> dict:

--- a/backend/backtesting/simple_backtest.py
+++ b/backend/backtesting/simple_backtest.py
@@ -24,7 +24,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Any, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 import numpy as np
@@ -2028,6 +2028,7 @@ def run_backtest(
     regime_hold_days: Optional[Dict[str, int]] = None,
     regime_sector_limits: Optional[Dict[str, float]] = None,
     use_broker_exit: bool = False,
+    progress_callback: Optional[Callable[[Dict[str, Any]], None]] = None,
 ) -> BacktestResult:
     """
     Run walk-forward portfolio backtest with realistic capital tracking.
@@ -2041,6 +2042,16 @@ def run_backtest(
     """
     start = datetime.strptime(start_date, "%Y-%m-%d")
     end = datetime.strptime(end_date, "%Y-%m-%d")
+
+    def _emit_progress(payload: Dict[str, Any]) -> None:
+        if progress_callback is None:
+            return
+        try:
+            progress_callback(payload)
+        except Exception:
+            logger.debug("Backtest progress callback failed", exc_info=True)
+
+    _emit_progress({"phase": "loading", "progress_pct": 0, "message": "Loading price data"})
 
     if signal_types is None:
         signal_types = ["volume", "quality"]
@@ -2132,6 +2143,16 @@ def run_backtest(
         return BacktestResult([], start, end, holding_days, initial_capital, [])
 
     logger.info(f"Testing on {len(trading_dates)} trading days")
+    total_days = len(trading_dates)
+    _emit_progress(
+        {
+            "phase": "running",
+            "progress_pct": 0,
+            "current": 0,
+            "total": total_days,
+            "message": f"Testing {total_days} trading days",
+        }
+    )
 
     # Build close price lookup for fast NAV computation
     close_lookup = build_close_lookup(prices_df)
@@ -2148,6 +2169,7 @@ def run_backtest(
     last_signal_date = None
     current_regime = "neutral"  # Tracks last-known regime for STEP 1 use
 
+    progress_step = max(1, len(trading_dates) // 100)
     for i, current_date in enumerate(trading_dates):
         current_date = pd.Timestamp(current_date)
 
@@ -2588,8 +2610,22 @@ def run_backtest(
             logger.info(f"Processed {i}/{len(trading_dates)} days, "
                         f"{len(completed_trades)} trades, "
                         f"NAV: NPR {nav:,.0f}")
+        if i == 0 or i == len(trading_dates) - 1 or i % progress_step == 0:
+            _emit_progress(
+                {
+                    "phase": "running",
+                    "progress_pct": int(round(((i + 1) / len(trading_dates)) * 100)),
+                    "current": i + 1,
+                    "total": len(trading_dates),
+                    "date": current_date.strftime("%Y-%m-%d"),
+                    "trades": len(completed_trades),
+                    "nav": float(nav),
+                    "message": f"{i + 1}/{len(trading_dates)} days",
+                }
+            )
 
     # Close remaining positions at last available price
+    _emit_progress({"phase": "finalizing", "progress_pct": 100, "message": "Finalizing positions"})
     for symbol, trade in current_positions.items():
         exit_fill = get_price_on_or_before_date(prices_df, symbol, end)
         if exit_fill:

--- a/backend/trading/strategy_registry.py
+++ b/backend/trading/strategy_registry.py
@@ -271,11 +271,20 @@ def _nepse_return(start_date: str, end_date: str) -> Dict[str, Any]:
     }
 
 
-def run_strategy_backtest(strategy: Dict[str, Any], *, start_date: str, end_date: str, capital: float) -> Dict[str, Any]:
+def run_strategy_backtest(
+    strategy: Dict[str, Any],
+    *,
+    start_date: str,
+    end_date: str,
+    capital: float,
+    progress_callback: Optional[Any] = None,
+) -> Dict[str, Any]:
     from backend.backtesting.simple_backtest import run_backtest
 
     config = copy.deepcopy(strategy.get("config") or {})
     config["initial_capital"] = float(capital)
+    if progress_callback is not None:
+        config["progress_callback"] = progress_callback
     result = run_backtest(start_date=start_date, end_date=end_date, **config)
     summary = _summarize_backtest_result(
         str(strategy.get("id") or "strategy"),

--- a/tests/unit/test_strategy_backtest_registry.py
+++ b/tests/unit/test_strategy_backtest_registry.py
@@ -55,7 +55,15 @@ def test_run_strategy_backtest_does_not_require_private_temp_runner(monkeypatch,
         ],
     )
 
-    monkeypatch.setattr("backend.backtesting.simple_backtest.run_backtest", lambda **_kwargs: result)
+    progress_events = []
+
+    def fake_run_backtest(**kwargs):
+        callback = kwargs.get("progress_callback")
+        if callback:
+            callback({"phase": "running", "progress_pct": 42, "message": "2/5 days"})
+        return result
+
+    monkeypatch.setattr("backend.backtesting.simple_backtest.run_backtest", fake_run_backtest)
     monkeypatch.setattr(strategy_registry, "_nepse_return", lambda *_args: {"return_pct": 5.0})
     monkeypatch.setattr(strategy_registry, "BACKTEST_RESULTS_DIR", tmp_path)
 
@@ -72,8 +80,10 @@ def test_run_strategy_backtest_does_not_require_private_temp_runner(monkeypatch,
         start_date="2026-01-01",
         end_date="2026-01-05",
         capital=1000.0,
+        progress_callback=progress_events.append,
     )
 
+    assert progress_events == [{"phase": "running", "progress_pct": 42, "message": "2/5 days"}]
     assert payload["summary"]["total_return_pct"] == 10.0
     assert payload["summary"]["sharpe_ratio"] == payload["summary"]["sharpe"]
     assert payload["summary"]["trade_count"] == payload["summary"]["total_trades"]


### PR DESCRIPTION
## Summary
- add a BT status column beside WR in the Saved Strategies table
- show live backtest percentage progress while the backtest loop processes trading days
- show CHART while chart generation is running, OK when complete, and FAIL on errors
- pass progress events from the backtest runner through the strategy registry into the TUI

## Tests
- python3 -m py_compile apps/tui/dashboard_tui.py backend/trading/strategy_registry.py backend/backtesting/simple_backtest.py
- python3 -m pytest tests/unit/test_strategy_backtest_registry.py tests/unit/test_dashboard_tui_intraday.py -q
- python3 -m pytest tests/unit -q