### PR TITLE
Fix Merolagani scrape and block promoter shares

### DIFF
--- a/backend/quant_pro/signal_ranking.py
+++ b/backend/quant_pro/signal_ranking.py
@@ -13,6 +13,17 @@ SYMBOL_ALIASES: Dict[str, str] = {
 }
 
 DEFAULT_BLOCKED_SIGNAL_SYMBOLS = frozenset({"KRBL", "UIC"})
+DEFAULT_PROMOTER_SHARE_SYMBOLS = frozenset(
+    {
+        "CYCLP",
+        "GBIMEP",
+        "HEIP",
+        "HIDCLP",
+        "NABILP",
+        "PROFLP",
+        "SRLIP",
+    }
+)
 BLOCKED_SYMBOLS_ENV = "NEPSE_BLOCKED_SYMBOLS"
 
 
@@ -43,6 +54,8 @@ def blocked_signal_symbol_reason(symbol: Any) -> Optional[str]:
         return "sector_index_not_tradeable"
     if token in blocked_signal_symbols():
         return "suspended_or_non_tradeable_symbol"
+    if token.endswith("PO") or token in DEFAULT_PROMOTER_SHARE_SYMBOLS:
+        return "promoter_share_not_tradeable"
     return None
 
 

--- a/backend/quant_pro/vendor_api.py
+++ b/backend/quant_pro/vendor_api.py
@@ -20,6 +20,12 @@ from .realtime_market import get_market_data_provider
 logger = logging.getLogger(__name__)
 
 
+def _normalize_epoch_seconds(value: int) -> int:
+    """Accept epoch seconds or milliseconds and send seconds to Merolagani."""
+    ts = int(value)
+    return ts // 1000 if ts > 10_000_000_000 else ts
+
+
 class _RateLimiter:
     """Token-bucket rate limiter (0.5 req/sec = 1 request per 2 seconds)."""
 
@@ -57,8 +63,8 @@ def fetch_ohlcv_chunk(symbol: str, start_ts: int, end_ts: int) -> pd.DataFrame:
         "type": "get_advanced_chart",
         "symbol": symbol,
         "resolution": "1D",
-        "rangeStartDate": int(start_ts),
-        "rangeEndDate": int(end_ts),
+        "rangeStartDate": _normalize_epoch_seconds(start_ts),
+        "rangeEndDate": _normalize_epoch_seconds(end_ts),
         "isAdjust": "1",
         "currencyCode": "NPR",
     }
@@ -69,7 +75,21 @@ def fetch_ohlcv_chunk(symbol: str, start_ts: int, end_ts: int) -> pd.DataFrame:
     }
     response = requests.get(url, params=params, headers=headers, timeout=15)
     response.raise_for_status()
-    data = response.json()
+    content_type = str(response.headers.get("content-type") or "").lower()
+    if "html" in content_type:
+        logger.warning(
+            "Merolagani returned HTML instead of OHLCV JSON for symbol=%s; treating as no data",
+            symbol,
+        )
+        return pd.DataFrame()
+    try:
+        data = response.json()
+    except ValueError:
+        logger.warning(
+            "Merolagani returned non-JSON OHLCV response for symbol=%s; treating as no data",
+            symbol,
+        )
+        return pd.DataFrame()
 
     # Merolagani returns {"s":"no_data"} for some index symbols/ranges.
     # Treat that as a valid empty result, not a schema failure worth retrying.

--- a/setup_data.py
+++ b/setup_data.py
@@ -89,13 +89,14 @@ def download_db():
 
 def load_symbols() -> list[str]:
     if ALL_SYMBOLS_FILE.exists():
+        from backend.quant_pro.signal_ranking import is_tradeable_signal_symbol
         syms = [s.strip() for s in ALL_SYMBOLS_FILE.read_text().splitlines() if s.strip()]
-        return [s for s in syms if not s.startswith("SECTOR::") and s != "NEPSE"]
+        return [s for s in syms if is_tradeable_signal_symbol(s)]
     return []
 
 
 def ts(dt: datetime) -> int:
-    return int(dt.timestamp() * 1000)
+    return int(dt.timestamp())
 
 
 def backfill_symbol(symbol: str, start: datetime, end: datetime) -> int:

--- a/tests/unit/test_paper_execution_service.py
+++ b/tests/unit/test_paper_execution_service.py
@@ -84,6 +84,22 @@ def test_paper_execution_rejects_suspended_symbol_visibly(tmp_path, monkeypatch)
     assert state["order_history"][0]["symbol"] == "UIC"
 
 
+def test_paper_execution_rejects_promoter_share_visibly(tmp_path, monkeypatch):
+    monkeypatch.setattr("backend.trading.paper_execution.current_nepal_datetime", _fixed_nst)
+    service = PaperExecutionService("account_1", account_dir=tmp_path, max_order_notional=500_000)
+
+    result = service.submit_order("account_1", "BUY", "NABILP", 100, 100.0, "strategy_paper", "volume")
+    state = service.get_account_execution_state("account_1")
+
+    assert not result.ok
+    assert result.risk_result["reason"] == "blocked_symbol"
+    assert result.risk_result["detail"] == "promoter_share_not_tradeable"
+    assert "Blocked symbol NABILP" in result.message
+    assert not state["open_orders"]
+    assert state["order_history"][0]["status"] == "REJECTED"
+    assert state["order_history"][0]["symbol"] == "NABILP"
+
+
 def test_paper_execution_migrates_legacy_tui_trade_log_without_duplicates(tmp_path):
     pd.DataFrame(columns=PORTFOLIO_COLS).to_csv(tmp_path / "paper_portfolio.csv", index=False)
     legacy_trade = pd.DataFrame(

--- a/tests/unit/test_signal_ranking.py
+++ b/tests/unit/test_signal_ranking.py
@@ -19,6 +19,16 @@ def test_tradeable_policy_blocks_indexes_and_suspended_symbols():
     assert is_tradeable_signal_symbol("NABIL")
 
 
+def test_tradeable_policy_blocks_promoter_shares_without_suffix_false_positives():
+    assert not is_tradeable_signal_symbol("NABILP")
+    assert not is_tradeable_signal_symbol("HIDCLP")
+    assert not is_tradeable_signal_symbol("KBLPO")
+    assert blocked_signal_symbol_reason("NABILP") == "promoter_share_not_tradeable"
+    assert blocked_signal_symbol_reason("KBLPO") == "promoter_share_not_tradeable"
+    assert is_tradeable_signal_symbol("NADEP")
+    assert is_tradeable_signal_symbol("RRHP")
+
+
 def test_tradeable_policy_honors_env_blocklist(monkeypatch):
     monkeypatch.setenv("NEPSE_BLOCKED_SYMBOLS", "AAA, BBB")
 

--- a/tests/unit/test_vendor_api.py
+++ b/tests/unit/test_vendor_api.py
@@ -6,13 +6,16 @@ from backend.quant_pro import vendor_api
 
 
 class _DummyResponse:
-    def __init__(self, payload):
+    def __init__(self, payload, *, content_type="application/json"):
         self._payload = payload
+        self.headers = {"content-type": content_type}
 
     def raise_for_status(self):
         return None
 
     def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
         return self._payload
 
 
@@ -24,6 +27,34 @@ def test_fetch_ohlcv_chunk_treats_no_data_as_empty(monkeypatch):
     )
 
     df = vendor_api.fetch_ohlcv_chunk("MANUFACTURING", 1704067200, 1775097600)
+
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty
+
+
+def test_fetch_ohlcv_chunk_normalizes_millisecond_timestamps(monkeypatch):
+    seen = {}
+
+    def fake_get(_url, *, params, **_kwargs):
+        seen.update(params)
+        return _DummyResponse({"s": "no_data"})
+
+    monkeypatch.setattr(vendor_api.requests, "get", fake_get)
+
+    vendor_api.fetch_ohlcv_chunk("NABIL", 1704067200000, 1775097600000)
+
+    assert seen["rangeStartDate"] == 1704067200
+    assert seen["rangeEndDate"] == 1775097600
+
+
+def test_fetch_ohlcv_chunk_treats_html_error_page_as_empty(monkeypatch):
+    monkeypatch.setattr(
+        vendor_api.requests,
+        "get",
+        lambda *args, **kwargs: _DummyResponse("<html>error</html>", content_type="text/html; charset=utf-8"),
+    )
+
+    df = vendor_api.fetch_ohlcv_chunk("ACLBSL", 1704067200, 1775097600)
 
     assert isinstance(df, pd.DataFrame)
     assert df.empty


### PR DESCRIPTION
## Summary
- Fix Merolagani OHLCV scrape by sending epoch seconds instead of milliseconds.
- Treat Merolagani HTML/non-JSON error responses as empty data instead of crashing the scraper.
- Block promoter-share symbols, including NABILP and *PO symbols, from signal selection and paper execution.

## Root Cause
Merolagani now rejects the millisecond timestamp parameters used by setup_data.py and returns an HTML error page, which surfaced as a JSONDecodeError during scrape retries.

## Validation
- python3 setup_data.py --scrape --days 30 --symbol NABIL
- python3 -m py_compile setup_data.py backend/quant_pro/vendor_api.py backend/quant_pro/signal_ranking.py backend/trading/paper_execution.py
- python3 -m pytest tests/unit/test_vendor_api.py tests/unit/test_signal_ranking.py tests/unit/test_paper_execution_service.py -q
- python3 -m pytest tests/unit -q

Closes #21
