### PR TITLE
Fix quick chart date labels on Windows

### DIFF
--- a/tests/unit/test_quick_chart.py
+++ b/tests/unit/test_quick_chart.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from validation import quick_chart
+
+
+def test_quick_chart_date_format_is_cross_platform():
+    assert "%-" not in quick_chart._MONTH_YEAR_LABEL
+    assert "%#" not in quick_chart._MONTH_YEAR_LABEL
+
+
+def test_generate_quick_chart_writes_png(tmp_path):
+    pytest.importorskip("matplotlib")
+    pytest.importorskip("pandas")
+
+    start = date(2026, 1, 1)
+    daily_nav = [
+        ((start + timedelta(days=i)).isoformat(), 1_000_000 + i * 1_000)
+        for i in range(80)
+    ]
+    result = {
+        "summary": {
+            "daily_nav": daily_nav,
+            "total_return_pct": 7.9,
+            "sharpe_ratio": 1.2,
+            "max_drawdown_pct": -2.1,
+            "trade_count": 4,
+            "win_rate_pct": 50.0,
+        },
+        "nepse": {"return_pct": 2.5},
+    }
+
+    path = quick_chart.generate_quick_chart(
+        result,
+        strategy_name="Test Strategy",
+        start_date=daily_nav[0][0],
+        end_date=daily_nav[-1][0],
+        output_dir=tmp_path,
+        auto_open=False,
+    )
+
+    assert path is not None
+    assert path.endswith(".png")
+    assert Path(path).exists()

--- a/validation/quick_chart.py
+++ b/validation/quick_chart.py
@@ -42,6 +42,7 @@ GOLD    = "#D1980B"
 
 
 _QUICK_CHARTS_DIR = Path(__file__).parent.parent / "reports" / "quick_charts"
+_MONTH_YEAR_LABEL = "%b '%y"
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -236,7 +237,7 @@ def generate_quick_chart(
         ax.grid(True, color=BORDER, linewidth=0.3, alpha=0.4)
         if show_date_axis:
             ax.xaxis.set_major_locator(mdates.MonthLocator())
-            ax.xaxis.set_major_formatter(mdates.DateFormatter("%-b '%y"))
+            ax.xaxis.set_major_formatter(mdates.DateFormatter(_MONTH_YEAR_LABEL))
             plt.setp(ax.xaxis.get_majorticklabels(), rotation=35, ha="right",
                      fontsize=7)
         else:
@@ -367,7 +368,7 @@ def generate_quick_chart(
 
     # Shared date axis on bottom chart
     ax_dd.xaxis.set_major_locator(mdates.MonthLocator())
-    ax_dd.xaxis.set_major_formatter(mdates.DateFormatter("%-b '%y"))
+    ax_dd.xaxis.set_major_formatter(mdates.DateFormatter(_MONTH_YEAR_LABEL))
     plt.setp(ax_dd.xaxis.get_majorticklabels(), rotation=35, ha="right", fontsize=7)
 
     # ── Stats panel ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fix quick chart date labels so chart generation works on Windows.
- Replace the Unix-only `%-b` date formatter with a cross-platform `%b` formatter.
- Add a quick chart regression test that renders a PNG from synthetic backtest data.

## Root Cause
Matplotlib delegated the `%-b` month format to the platform strftime implementation. That format is accepted on macOS/Linux but raises `Invalid format string` on Windows, causing the dashboard Chart button to fail after backtests.

## Validation
- python3 -m py_compile validation/quick_chart.py tests/unit/test_quick_chart.py
- python3 -m pytest tests/unit/test_quick_chart.py tests/unit/test_strategy_backtest_registry.py -q
