### PR TITLE
Fix MCP startup in paper-only mode

### DIFF
--- a/backend/trading/live_trader.py
+++ b/backend/trading/live_trader.py
@@ -124,7 +124,28 @@ from backend.quant_pro.tms_audit import (
 )
 
 class _TmsStub:
-    pass
+    def __init__(self, *args: Any, **kwargs: Any):
+        pass
+
+
+@dataclass
+class PaperOnlyLiveSettings:
+    """Safe live-execution settings stub for the public paper-only build."""
+
+    mode: str = "paper"
+    enabled: bool = False
+    strategy_automation_enabled: bool = False
+    auto_exits_enabled: bool = False
+    owner_confirm_required: bool = True
+    max_order_notional: float = 0.0
+    max_daily_orders: int = 0
+    symbol_cooldown_secs: int = 0
+    max_price_deviation_pct: float = 2.5
+
+
+def validate_live_setup(settings: PaperOnlyLiveSettings, *, interactive: bool = False) -> List[str]:
+    """Live brokerage connectors are intentionally unavailable in this build."""
+    return []
 
 TMSBrowserExecutor = _TmsStub
 
@@ -2356,9 +2377,11 @@ class LiveTrader:
         self.sector_limit = float(self.strategy_config.get("sector_limit") or self.regime_sector_limits.get("neutral", 0.35))
         requested_execution_mode = str(getattr(args, "mode", "paper") or "paper").strip().lower()
         self.execution_mode = "paper"
+        self.live_settings = PaperOnlyLiveSettings()
         self.live_settings.mode = self.execution_mode
         self.live_settings.enabled = False
         self.live_execution_enabled = False
+        self.live_execution_service = None
         self.dual_execution_mode = False
         self.shadow_live_mode = False
         self.requested_execution_mode = requested_execution_mode

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -43,6 +43,21 @@ def test_mcp_tool_adapters_route_to_service():
     assert "reconcile_live_state" not in tools
 
 
+def test_env_mcp_control_plane_starts_in_paper_only_mode(monkeypatch, tmp_path):
+    from backend.quant_pro.control_plane.command_service import build_env_live_trader_control_plane
+
+    monkeypatch.setenv("NEPSE_MCP_PAPER_PORTFOLIO", str(tmp_path / "paper_portfolio.csv"))
+    monkeypatch.setenv("NEPSE_MCP_ACCOUNT_ID", "account_1")
+    monkeypatch.setenv("NEPSE_ACTIVE_ACCOUNT_ID", "account_1")
+
+    service = build_env_live_trader_control_plane()
+
+    assert service.mode == TradingMode.PAPER
+    assert service.paper_execution_service is not None
+    assert getattr(service.trader, "live_execution_enabled") is False
+    assert getattr(service.trader, "live_settings").mode == "paper"
+
+
 def test_mcp_tool_adapters_expose_paper_agent_graph(monkeypatch):
     monkeypatch.setattr(
         "apps.mcp.server.run_paper_decision",


### PR DESCRIPTION
## Summary
- Fix MCP HTTP startup in the public paper-only build.
- Add a safe `PaperOnlyLiveSettings` stub so `LiveTrader` exposes the settings expected by the control plane.
- Initialize `live_execution_service` to `None` and cover environment-driven MCP control-plane startup with a regression test.

## Root Cause
`build_env_live_trader_control_plane()` constructs `LiveTrader` for the MCP endpoint. In the current public paper-only build, `LiveTrader.__init__` wrote to `self.live_settings` before that attribute existed, causing `AttributeError: LiveTrader object has no attribute live_settings` during `./scripts/mcp/run_http_server.sh` startup.

## Validation
- python3 -m py_compile backend/trading/live_trader.py apps/mcp/server.py tests/unit/test_mcp_server.py backend/agents/agent_analyst.py
- python3 -m pytest tests/unit/test_agent_bridge.py tests/unit/test_mcp_server.py tests/unit/test_control_plane_command_service.py -q
- ./scripts/mcp/run_http_server.sh starts successfully and reaches Uvicorn on http://127.0.0.1:8765
