### PR TITLE
Let charts use saved backtest artifacts

### DIFF
--- a/apps/tui/dashboard_tui.py
+++ b/apps/tui/dashboard_tui.py
@@ -6693,18 +6693,14 @@ class NepseDashboard(App):
         elif bid == "strategy-btn-chart":
             selected = self._selected_strategy_payload()
             selected_id = str((selected or {}).get("id") or getattr(self, "_selected_strategy_id", "") or "").strip()
-            result = dict(getattr(self, "_strategy_backtest_result", {}) or {})
-            if result and str((result.get("strategy") or {}).get("id") or "") != selected_id:
-                result = {}
-            if not result and selected_id:
-                result = dict(strategy_registry.load_strategy_backtest_result(selected_id) or {})
+            result = self._selected_strategy_chart_result(selected_id)
             if not result:
-                self._set_status("Run a backtest first — no result to chart")
+                self._set_status("No chartable saved backtest artifact for this strategy")
             else:
                 try:
                     from validation.quick_chart import generate_quick_chart
                     from backend.quant_pro.database import get_db_path as _get_db_path
-                    name   = str((selected or {}).get("name") or "Strategy")
+                    name   = str((selected or {}).get("name") or (result.get("strategy") or {}).get("name") or "Strategy")
                     window = dict(result.get("window") or {})
                     start  = str(window.get("start") or self.query_one("#strategy-inp-backtest-start", Input).value or "").strip()
                     end    = str(window.get("end") or self.query_one("#strategy-inp-backtest-end", Input).value or "").strip()
@@ -7407,17 +7403,13 @@ class NepseDashboard(App):
             widget = self.query_one("#strategy-backtest-summary", Static)
         except Exception:
             return
-        result = dict(getattr(self, "_strategy_backtest_result", {}) or {})
         selected_id = str(getattr(self, "_selected_strategy_id", "") or "").strip()
-        if result and str((result.get("strategy") or {}).get("id") or "") != selected_id:
-            result = {}
-        if not result and selected_id:
-            result = dict(strategy_registry.load_strategy_backtest_result(selected_id) or {})
+        result = self._selected_strategy_chart_result(selected_id)
         if not result:
             widget.update(
                 Text.from_markup(
                     f"[#8aa0b5]Backtest artifacts[/] data/strategy_registry/backtests/\n"
-                    f"[#708091]Run a backtest from this tab to store the latest result for the selected strategy.[/]"
+                    f"[#708091]Run a backtest from this tab, or select a strategy with a saved chartable artifact.[/]"
                 )
             )
             return
@@ -7436,6 +7428,15 @@ class NepseDashboard(App):
                 f"[#8aa0b5]Saved[/] data/strategy_registry/backtests/{str(result.get('strategy', {}).get('id') or 'strategy')}_latest.json"
             )
         )
+
+    def _selected_strategy_chart_result(self, strategy_id: str) -> dict:
+        sid = str(strategy_id or "").strip()
+        result = dict(getattr(self, "_strategy_backtest_result", {}) or {})
+        if result and str((result.get("strategy") or {}).get("id") or "") != sid:
+            result = {}
+        if result and len(list((result.get("summary") or {}).get("daily_nav") or [])) >= 5:
+            return result
+        return dict(strategy_registry.load_strategy_chart_result(sid) or {})
 
     def _strategy_saved_metrics(self, strategy_id: str) -> Optional[dict]:
         return strategy_registry.comparison_metrics_for_strategy(strategy_id)

--- a/backend/trading/strategy_registry.py
+++ b/backend/trading/strategy_registry.py
@@ -339,6 +339,50 @@ def load_strategy_backtest_result(strategy_id: str) -> Optional[Dict[str, Any]]:
     return payload
 
 
+def _row_chart_payload(row: Dict[str, Any], *, snapshot: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    strategy = dict(row.get("strategy") or {})
+    sid = str(strategy.get("id") or row.get("id") or "").strip()
+    if not sid:
+        return None
+    strategy.setdefault("id", sid)
+    strategy.setdefault("name", str(row.get("name") or sid))
+    summary = dict(row.get("summary") or {})
+    if not summary:
+        summary = {k: v for k, v in row.items() if k not in {"strategy", "window", "nepse"}}
+    if "daily_nav" not in summary and row.get("daily_nav") is not None:
+        summary["daily_nav"] = row.get("daily_nav")
+    if len(list(summary.get("daily_nav") or [])) < 5:
+        return None
+    return {
+        "strategy": strategy,
+        "window": dict(row.get("window") or snapshot.get("window") or {}),
+        "nepse": dict(row.get("nepse") or snapshot.get("nepse") or {}),
+        "summary": summary,
+        "generated_at": str(row.get("generated_at") or snapshot.get("generated_at") or ""),
+    }
+
+
+def load_strategy_chart_result(strategy_id: str) -> Optional[Dict[str, Any]]:
+    """Load a saved backtest artifact with enough data to render a quick chart."""
+    sid = str(strategy_id or "").strip()
+    if not sid:
+        return None
+    latest = load_strategy_backtest_result(sid)
+    if latest and len(list((latest.get("summary") or {}).get("daily_nav") or [])) >= 5:
+        return latest
+
+    snapshot = load_strategy_comparison_snapshot()
+    if not snapshot:
+        return None
+    for row in list(snapshot.get("strategies") or []):
+        if not isinstance(row, dict):
+            continue
+        row_sid = str((row.get("strategy") or {}).get("id") or row.get("id") or "").strip()
+        if row_sid == sid:
+            return _row_chart_payload(row, snapshot=snapshot)
+    return None
+
+
 def _normalize_metrics(metrics: Dict[str, Any], *, window: Dict[str, Any], nepse: Dict[str, Any]) -> Dict[str, Any]:
     row = dict(metrics or {})
     if "sharpe_ratio" not in row and "sharpe" in row:

--- a/tests/unit/test_strategy_backtest_registry.py
+++ b/tests/unit/test_strategy_backtest_registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 from datetime import datetime
 
@@ -99,6 +100,66 @@ def test_run_strategy_backtest_does_not_require_private_temp_runner(monkeypatch,
     assert metrics["vs_nepse_pct_points"] == 5.0
     assert metrics["trade_count"] == metrics["total_trades"]
     assert metrics["sharpe_ratio"] == metrics["sharpe"]
+
+
+def test_load_strategy_chart_result_uses_comparison_snapshot_when_latest_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(strategy_registry, "BACKTEST_RESULTS_DIR", tmp_path)
+    comparison_path = tmp_path / "registry_strategies_vs_nepse_latest.json"
+    monkeypatch.setattr(strategy_registry, "COMPARISON_LATEST_JSON", comparison_path)
+    comparison_path.write_text(
+        json.dumps(
+            {
+                "window": {"start": "2026-01-01", "end": "2026-01-08", "capital": 1000.0},
+                "nepse": {"return_pct": 2.0},
+                "generated_at": "2026-01-08T12:00:00",
+                "strategies": [
+                    {
+                        "id": "demo",
+                        "name": "Demo",
+                        "summary": {
+                            "total_return_pct": 5.0,
+                            "daily_nav": [
+                                ["2026-01-01", 1000.0],
+                                ["2026-01-02", 1010.0],
+                                ["2026-01-05", 1020.0],
+                                ["2026-01-06", 1030.0],
+                                ["2026-01-07", 1040.0],
+                                ["2026-01-08", 1050.0],
+                            ],
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = strategy_registry.load_strategy_chart_result("demo")
+
+    assert payload is not None
+    assert payload["strategy"]["id"] == "demo"
+    assert payload["window"]["start"] == "2026-01-01"
+    assert payload["nepse"]["return_pct"] == 2.0
+    assert payload["summary"]["daily_nav"][-1] == ["2026-01-08", 1050.0]
+
+
+def test_load_strategy_chart_result_ignores_metric_only_snapshot(monkeypatch, tmp_path):
+    monkeypatch.setattr(strategy_registry, "BACKTEST_RESULTS_DIR", tmp_path)
+    comparison_path = tmp_path / "registry_strategies_vs_nepse_latest.json"
+    monkeypatch.setattr(strategy_registry, "COMPARISON_LATEST_JSON", comparison_path)
+    comparison_path.write_text(
+        json.dumps(
+            {
+                "window": {"start": "2026-01-01", "end": "2026-01-08"},
+                "strategies": [
+                    {"id": "demo", "name": "Demo", "summary": {"total_return_pct": 5.0}},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert strategy_registry.load_strategy_chart_result("demo") is None
 
 
 def test_run_backtest_broker_exit_uses_public_db_path(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Let the Strategy Registry Chart button render from saved chartable backtest artifacts instead of requiring a fresh run.
- Add `load_strategy_chart_result()` to centralize saved artifact lookup for `{strategy_id}_latest.json` and comparison snapshots with `daily_nav`.
- Update the backtest summary panel to use the same saved-artifact lookup and clarify when only metric-only data is available.

## User Impact
Users can select a strategy with an existing saved backtest and press Chart directly. They no longer need to rerun the backtest just to generate the chart.

## Validation
- python3 -m py_compile apps/tui/dashboard_tui.py backend/trading/strategy_registry.py tests/unit/test_strategy_backtest_registry.py
- python3 -m pytest tests/unit/test_strategy_backtest_registry.py tests/unit/test_quick_chart.py tests/unit/test_dashboard_tui_intraday.py -q
- Generated a chart locally from saved default_c5_latest.json without rerunning a backtest
