### PR TITLE
Fix account NAV drawdown and Kalimati prices

### DIFF
--- a/apps/tui/dashboard_tui.py
+++ b/apps/tui/dashboard_tui.py
@@ -584,7 +584,11 @@ def _build_account_seed_state(portfolio_df: pd.DataFrame, target_nav: float) -> 
     if cash < 0:
         raise ValueError(f"Target NAV is below current marked portfolio value {_npr_k(positions_value)}")
     today = datetime.now().strftime("%Y-%m-%d")
-    state = {"cash": cash, "daily_start_nav": round(float(target_nav), 2)}
+    state = {
+        "cash": cash,
+        "daily_start_nav": round(float(target_nav), 2),
+        "initial_capital": round(float(target_nav), 2),
+    }
     nav_log = pd.DataFrame(
         [
             {
@@ -969,6 +973,50 @@ def _load_manual_paper_cash(total_cost: float, nav_log: Optional[pd.DataFrame] =
         except Exception:
             pass
     return max(0.0, float(INITIAL_CAPITAL) - float(total_cost))
+
+
+def _positive_float(value) -> Optional[float]:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if number > 0 else None
+
+
+def _account_initial_capital_from_files(account_dir: Path, fallback: float = INITIAL_CAPITAL) -> float:
+    state_path = account_dir / "paper_state.json"
+    nav_path = account_dir / "paper_nav_log.csv"
+    portfolio_path = account_dir / "paper_portfolio.csv"
+    trade_log_path = account_dir / "paper_trade_log.csv"
+
+    state = load_runtime_state(str(state_path))
+    if isinstance(state, dict):
+        for key in ("initial_capital", "daily_start_nav"):
+            value = _positive_float(state.get(key))
+            if value is not None:
+                return value
+
+    if nav_path.exists():
+        try:
+            nav_log = pd.read_csv(nav_path)
+            if not nav_log.empty and "NAV" in nav_log.columns:
+                value = _positive_float(nav_log.iloc[0].get("NAV"))
+                if value is not None:
+                    return value
+        except Exception:
+            pass
+
+    cash = _positive_float(state.get("cash") if isinstance(state, dict) else None)
+    if cash is not None:
+        try:
+            portfolio = pd.read_csv(portfolio_path) if portfolio_path.exists() else pd.DataFrame()
+            trades = pd.read_csv(trade_log_path) if trade_log_path.exists() else pd.DataFrame()
+        except Exception:
+            portfolio = trades = pd.DataFrame()
+        if portfolio.empty and trades.empty:
+            return cash
+
+    return float(fallback)
 
 
 def _tms_health_flag(health: dict, key: str) -> bool:
@@ -2396,6 +2444,7 @@ def _compute_account_portfolio_stats(md: MD, account_dir: Path) -> dict:
     port = pd.read_csv(_port_path) if _port_path.exists() else pd.DataFrame()
     nav_log = pd.read_csv(_nav_path) if _nav_path.exists() else pd.DataFrame()
     trade_log = pd.read_csv(_tl_path) if _tl_path.exists() else pd.DataFrame()
+    account_capital = _account_initial_capital_from_files(account_dir)
 
     positions = []
     total_cost = total_value = 0.0
@@ -2437,7 +2486,7 @@ def _compute_account_portfolio_stats(md: MD, account_dir: Path) -> dict:
             })
 
     # Cash from paper_state.json
-    cash = float(INITIAL_CAPITAL)
+    cash = float(account_capital)
     if _state_path.exists():
         try:
             _ps = _json.loads(_state_path.read_text())
@@ -2447,13 +2496,13 @@ def _compute_account_portfolio_stats(md: MD, account_dir: Path) -> dict:
         except Exception:
             pass
     elif total_cost > 0:
-        cash = max(0.0, float(INITIAL_CAPITAL) - total_cost)
+        cash = max(0.0, float(account_capital) - total_cost)
 
     nav = cash + total_value
-    baseline_nav = float(INITIAL_CAPITAL)
+    baseline_nav = float(account_capital)
     if not nav_log.empty and "NAV" in nav_log.columns:
         try:
-            baseline_nav = float(nav_log.iloc[0]["NAV"] or INITIAL_CAPITAL)
+            baseline_nav = float(nav_log.iloc[0]["NAV"] or account_capital)
         except Exception:
             pass
     total_return = (nav - baseline_nav) / baseline_nav * 100 if baseline_nav > 0 else 0.0
@@ -4309,10 +4358,11 @@ class NepseDashboard(App):
         if block_reason:
             return block_reason
         account_id = str(getattr(self, "__dict__", {}).get("_current_account_id", "") or "account_1")
+        account_dir = _account_dir(account_id)
         service = PaperExecutionService(
             account_id,
-            account_dir=_account_dir(account_id),
-            initial_capital=float(INITIAL_CAPITAL),
+            account_dir=account_dir,
+            initial_capital=_account_initial_capital_from_files(account_dir),
         )
         result = service.submit_order(
             account_id,
@@ -4433,10 +4483,11 @@ class NepseDashboard(App):
             return
 
         account_id = str(getattr(self, "__dict__", {}).get("_current_account_id", "") or "account_1")
+        account_dir = _account_dir(account_id)
         service = PaperExecutionService(
             account_id,
-            account_dir=_account_dir(account_id),
-            initial_capital=float(INITIAL_CAPITAL),
+            account_dir=account_dir,
+            initial_capital=_account_initial_capital_from_files(account_dir),
         )
         result = service.match_open_orders(
             account_id,
@@ -4846,8 +4897,12 @@ class NepseDashboard(App):
             strategy = strategy_registry.load_strategy(strategy_id) if strategy_id else None
             config = dict((strategy or {}).get("config") or {}) or dict(LONG_TERM_CONFIG)
             account_dir = _account_dir(account_id)
+            account_capital = _account_initial_capital_from_files(
+                account_dir,
+                float(config.get("initial_capital") or INITIAL_CAPITAL),
+            )
             engine = TUITradingEngine(
-                capital=float(config.get("initial_capital") or INITIAL_CAPITAL),
+                capital=account_capital,
                 signal_types=list(config.get("signal_types") or list(LONG_TERM_CONFIG.get("signal_types") or [])),
                 max_positions=int(config.get("max_positions") or LONG_TERM_CONFIG.get("max_positions") or 5),
                 holding_days=int(config.get("holding_days") or LONG_TERM_CONFIG.get("holding_days") or 40),
@@ -7811,7 +7866,20 @@ class NepseDashboard(App):
         if not isinstance(cash, (int, float)):
             cash = _load_manual_paper_cash(0.0, nav_log)
         nav_value = None
-        if isinstance(nav_log, pd.DataFrame) and not nav_log.empty and "NAV" in nav_log.columns:
+        if account_dir and hasattr(self, "md"):
+            try:
+                stats = _compute_account_portfolio_stats(self.md, account_dir)
+                nav_value = float(stats.get("nav") or 0.0)
+                cash = float(stats.get("cash") or cash)
+            except Exception:
+                nav_value = None
+        elif not account_dir and isinstance(getattr(self, "_stats", None), dict) and self._stats:
+            try:
+                nav_value = float(self._stats.get("nav") or 0.0)
+                cash = float(self._stats.get("cash") or cash)
+            except Exception:
+                nav_value = None
+        if nav_value is None and isinstance(nav_log, pd.DataFrame) and not nav_log.empty and "NAV" in nav_log.columns:
             try:
                 nav_value = float(nav_log.iloc[-1]["NAV"])
             except Exception:
@@ -8152,8 +8220,12 @@ class NepseDashboard(App):
             _new_strategy = strategy_registry.load_strategy(strategy_registry.default_strategy_for_account(account_id))
             _new_config = dict((_new_strategy or {}).get("config") or {}) or dict(LONG_TERM_CONFIG)
             _new_adir = _account_dir(account_id)
+            _new_capital = _account_initial_capital_from_files(
+                _new_adir,
+                float(_new_config.get("initial_capital") or target_nav or INITIAL_CAPITAL),
+            )
             _new_engine = TUITradingEngine(
-                capital=float(_new_config.get("initial_capital") or INITIAL_CAPITAL),
+                capital=_new_capital,
                 signal_types=list(_new_config.get("signal_types") or list(LONG_TERM_CONFIG.get("signal_types") or [])),
                 max_positions=int(_new_config.get("max_positions") or LONG_TERM_CONFIG.get("max_positions") or 5),
                 holding_days=int(_new_config.get("holding_days") or LONG_TERM_CONFIG.get("holding_days") or 40),
@@ -8283,11 +8355,13 @@ class NepseDashboard(App):
         state = load_runtime_state(str(PAPER_STATE_FILE))
         state["cash"] = target_cash
         state["daily_start_nav"] = target_nav
+        state["initial_capital"] = target_nav
         save_runtime_state(str(PAPER_STATE_FILE), state)
 
         tui_state = load_runtime_state(str(TUI_PAPER_STATE_FILE))
         tui_state["cash"] = target_cash
         tui_state["daily_start_nav"] = target_nav
+        tui_state["initial_capital"] = target_nav
         save_runtime_state(str(TUI_PAPER_STATE_FILE), tui_state)
 
         nav_log = _load_nav_log()

--- a/backend/market/kalimati_market.py
+++ b/backend/market/kalimati_market.py
@@ -1,11 +1,10 @@
 """
-Kalimati Market — scraper + SQLite data layer.
+Kalimati Market - scraper + SQLite data layer.
 Fetches daily vegetable/fruit prices from kalimatimarket.gov.np and stores them locally.
 """
 from __future__ import annotations
 
 import datetime
-import re
 import time
 from pathlib import Path
 
@@ -19,7 +18,7 @@ from sqlalchemy.orm import DeclarativeBase, Session, relationship
 
 from backend.market.kalimati_translations import translate_name, translate_unit
 
-# ── Database ──────────────────────────────────────────────────────────────────
+# -- Database -----------------------------------------------------------------
 
 DB_PATH = Path(__file__).parent / "kalimati.db"
 _engine = create_engine(f"sqlite:///{DB_PATH}", echo=False)
@@ -31,36 +30,42 @@ class _Base(DeclarativeBase):
 
 class KCommodity(_Base):
     __tablename__ = "k_commodities"
-    id            = Column(Integer, primary_key=True, autoincrement=True)
-    name_nepali   = Column(String, unique=True, nullable=False)
-    name_english  = Column(String, nullable=False)
-    unit_nepali   = Column(String)
-    unit_english  = Column(String)
-    prices        = relationship("KPrice", back_populates="commodity",
-                                 cascade="all, delete-orphan")
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name_nepali = Column(String, unique=True, nullable=False)
+    name_english = Column(String, nullable=False)
+    unit_nepali = Column(String)
+    unit_english = Column(String)
+    prices = relationship(
+        "KPrice",
+        back_populates="commodity",
+        cascade="all, delete-orphan",
+    )
 
 
 class KPrice(_Base):
     __tablename__ = "k_prices"
-    id            = Column(Integer, primary_key=True, autoincrement=True)
-    commodity_id  = Column(Integer, ForeignKey("k_commodities.id"), nullable=False)
-    date          = Column(String, nullable=False)   # YYYY-MM-DD
-    min_price     = Column(Float)
-    max_price     = Column(Float)
-    avg_price     = Column(Float)
-    scraped_at    = Column(DateTime, default=datetime.datetime.now)
-    commodity     = relationship("KCommodity", back_populates="prices")
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    commodity_id = Column(Integer, ForeignKey("k_commodities.id"), nullable=False)
+    date = Column(String, nullable=False)  # YYYY-MM-DD
+    min_price = Column(Float)
+    max_price = Column(Float)
+    avg_price = Column(Float)
+    scraped_at = Column(DateTime, default=datetime.datetime.now)
+    commodity = relationship("KCommodity", back_populates="prices")
 
 
 def init_kalimati_db() -> None:
     _Base.metadata.create_all(_engine)
 
 
-# ── Scraper ───────────────────────────────────────────────────────────────────
+# -- Scraper ------------------------------------------------------------------
 
+_API_URLS = [
+    "https://kalimatimarket.gov.np/api/daily-prices/en",
+]
 _PRICE_URLS = [
-    "https://kalimatimarket.gov.np/lang/en/price",
     "https://kalimatimarket.gov.np/price",
+    "https://kalimatimarket.gov.np/lang/en/price",
 ]
 _HEADERS = {
     "User-Agent": (
@@ -68,6 +73,7 @@ _HEADERS = {
         "AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/122.0.0.0 Safari/537.36"
     ),
+    "Accept": "application/json,text/html;q=0.9,*/*;q=0.8",
     "Accept-Language": "en-US,en;q=0.9,ne;q=0.8",
 }
 _DIGIT_MAP = str.maketrans("०१२३४५६७८९", "0123456789")
@@ -88,9 +94,48 @@ def _is_english(text: str) -> bool:
     return sum(1 for c in text if c.isascii() and c.isalpha()) > len(text) * 0.5
 
 
+def _rows_from_api_payload(payload: dict) -> list[dict]:
+    api_date = str(payload.get("date") or datetime.date.today().isoformat())[:10]
+    prices = payload.get("prices") if isinstance(payload, dict) else None
+    if not isinstance(prices, list):
+        return []
+
+    rows = []
+    for item in prices:
+        if not isinstance(item, dict):
+            continue
+        name_raw = str(item.get("commodityname") or item.get("name") or "").strip()
+        unit_raw = str(item.get("commodityunit") or item.get("unit") or "").strip()
+        avg_v = _to_float(str(item.get("avgprice") or item.get("avg") or ""))
+        if not name_raw or avg_v is None:
+            continue
+        rows.append({
+            "name_nepali": name_raw,
+            "name_english": name_raw if _is_english(name_raw) else translate_name(name_raw),
+            "unit_nepali": unit_raw,
+            "unit_english": translate_unit(unit_raw),
+            "min": _to_float(str(item.get("minprice") or item.get("min") or "")) or 0.0,
+            "max": _to_float(str(item.get("maxprice") or item.get("max") or "")) or 0.0,
+            "avg": avg_v,
+            "date": api_date,
+        })
+    return rows
+
+
 def fetch_kalimati_prices(timeout: int = 15) -> list[dict]:
-    """Scrape Kalimati market. Returns list of dicts with name/unit/min/max/avg."""
+    """Fetch Kalimati market prices. Returns list of dicts with name/unit/min/max/avg."""
     last_err = None
+    for url in _API_URLS:
+        try:
+            resp = requests.get(url, headers=_HEADERS, timeout=timeout)
+            resp.raise_for_status()
+            rows = _rows_from_api_payload(resp.json())
+            if rows:
+                return rows
+        except Exception as e:
+            last_err = e
+            time.sleep(1)
+
     for url in _PRICE_URLS:
         try:
             resp = requests.get(url, headers=_HEADERS, timeout=timeout)
@@ -113,9 +158,9 @@ def fetch_kalimati_prices(timeout: int = 15) -> list[dict]:
                     continue
                 name_raw = tds[0].get_text(strip=True)
                 unit_raw = tds[1].get_text(strip=True) if len(tds) > 4 else ""
-                min_v  = _to_float(tds[-3].get_text(strip=True))
-                max_v  = _to_float(tds[-2].get_text(strip=True))
-                avg_v  = _to_float(tds[-1].get_text(strip=True))
+                min_v = _to_float(tds[-3].get_text(strip=True))
+                max_v = _to_float(tds[-2].get_text(strip=True))
+                avg_v = _to_float(tds[-1].get_text(strip=True))
                 if not name_raw or avg_v is None:
                     continue
 
@@ -126,12 +171,11 @@ def fetch_kalimati_prices(timeout: int = 15) -> list[dict]:
                     name_np = name_raw
                     name_en = translate_name(name_raw)
 
-                unit_en = translate_unit(unit_raw)
                 rows.append({
                     "name_nepali": name_np,
                     "name_english": name_en,
                     "unit_nepali": unit_raw,
-                    "unit_english": unit_en,
+                    "unit_english": translate_unit(unit_raw),
                     "min": min_v or 0.0,
                     "max": max_v or 0.0,
                     "avg": avg_v,
@@ -144,7 +188,7 @@ def fetch_kalimati_prices(timeout: int = 15) -> list[dict]:
     raise RuntimeError(f"Kalimati fetch failed: {last_err}")
 
 
-# ── DB write ──────────────────────────────────────────────────────────────────
+# -- DB write -----------------------------------------------------------------
 
 def store_kalimati_prices(rows: list[dict], date: str | None = None) -> int:
     """Store scraped rows into DB. Returns number stored."""
@@ -167,7 +211,8 @@ def store_kalimati_prices(rows: list[dict], date: str | None = None) -> int:
                     comm.name_english = r["name_english"]
 
             existing = session.query(KPrice).filter_by(
-                commodity_id=comm.id, date=date
+                commodity_id=comm.id,
+                date=date,
             ).first()
             if existing:
                 existing.min_price = r["min"]
@@ -186,7 +231,7 @@ def store_kalimati_prices(rows: list[dict], date: str | None = None) -> int:
     return len(rows)
 
 
-# ── DB read ───────────────────────────────────────────────────────────────────
+# -- DB read ------------------------------------------------------------------
 
 def get_kalimati_display_rows() -> list[dict]:
     """Return latest price row per commodity with prev-day change calculation."""
@@ -200,7 +245,6 @@ def get_kalimati_display_rows() -> list[dict]:
             .scalar()
         )
 
-        # Build prev-day map
         prev_map: dict[int, float] = {}
         if prev_date:
             for p, c in (
@@ -248,10 +292,11 @@ def refresh_kalimati() -> tuple[list[dict], str]:
     """Fetch + store + return display rows. Returns (rows, status_msg)."""
     try:
         raw = fetch_kalimati_prices()
-        n = store_kalimati_prices(raw)
+        price_date = next((str(r.get("date"))[:10] for r in raw if r.get("date")), None)
+        n = store_kalimati_prices(raw, date=price_date)
         rows = get_kalimati_display_rows()
         ts = datetime.datetime.now().strftime("%H:%M:%S")
         return rows, f"Kalimati: {n} items  Updated {ts}"
     except Exception as e:
-        rows = get_kalimati_display_rows()  # return cached
+        rows = get_kalimati_display_rows()
         return rows, f"Kalimati fetch failed: {e}"

--- a/backend/trading/paper_execution.py
+++ b/backend/trading/paper_execution.py
@@ -57,6 +57,14 @@ from validation.transaction_costs import TransactionCostModel as NepseFees
 PAPER_ORDER_STATUSES = {"OPEN", "FILLED", "CANCELLED", "REJECTED"}
 
 
+def _positive_float(value: Any) -> Optional[float]:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if number > 0 else None
+
+
 @dataclass
 class PaperOrder:
     order_id: str
@@ -257,11 +265,10 @@ class PaperExecutionService:
         self.account_id = str(account_id or "account_1")
         self.account_dir = Path(account_dir) if account_dir else Path(get_runtime_dir(__file__)) / "accounts" / self.account_id
         ensure_dir(self.account_dir)
-        self.initial_capital = float(initial_capital)
+        self.configured_initial_capital = float(initial_capital)
         self.strategy_id = str(strategy_id or "")
         self.max_positions = int(max_positions)
         self.sector_limit = float(sector_limit)
-        self.max_order_notional = float(max_order_notional or (self.initial_capital / max(1, self.max_positions)))
         self.max_quote_age_seconds = int(max_quote_age_seconds)
         self.max_daily_turnover_pct = float(max_daily_turnover_pct)
         self.max_daily_loss_pct = float(max_daily_loss_pct)
@@ -276,8 +283,41 @@ class PaperExecutionService:
         self.structured_log_file = self.account_dir / "paper_execution.jsonl"
         self.manifest_dir = ensure_dir(self.account_dir / "strategy_runs")
 
+        self.initial_capital = self._resolve_account_initial_capital(self.configured_initial_capital)
+        self.max_order_notional = float(max_order_notional or (self.initial_capital / max(1, self.max_positions)))
+
         self._ensure_files()
         self._migrate_legacy_tui_files()
+
+    def _resolve_account_initial_capital(self, fallback: float) -> float:
+        """Prefer account seed NAV over the global strategy default."""
+        state = load_runtime_state(str(self.state_file))
+        for key in ("initial_capital", "daily_start_nav"):
+            value = _positive_float(state.get(key) if isinstance(state, dict) else None)
+            if value is not None:
+                return value
+
+        if self.nav_log_file.exists():
+            try:
+                nav_df = pd.read_csv(self.nav_log_file)
+                if not nav_df.empty and "NAV" in nav_df.columns:
+                    value = _positive_float(nav_df.iloc[0].get("NAV"))
+                    if value is not None:
+                        return value
+            except Exception:
+                pass
+
+        cash = _positive_float(state.get("cash") if isinstance(state, dict) else None)
+        if cash is not None:
+            try:
+                has_positions = bool(load_portfolio(str(self.portfolio_file)))
+                has_trades = not load_trade_log_df(str(self.trade_log_file)).empty
+            except Exception:
+                has_positions = has_trades = False
+            if not has_positions and not has_trades:
+                return cash
+
+        return float(fallback)
 
     def _ensure_files(self) -> None:
         _ensure_csv(self.portfolio_file, PORTFOLIO_COLS)
@@ -286,7 +326,11 @@ class PaperExecutionService:
         if not self.state_file.exists():
             save_runtime_state(
                 str(self.state_file),
-                {"cash": self.initial_capital, "daily_start_nav": self.initial_capital},
+                {
+                    "cash": self.initial_capital,
+                    "daily_start_nav": self.initial_capital,
+                    "initial_capital": self.initial_capital,
+                },
             )
         if not self.orders_file.exists():
             _write_json_locked(self.orders_file, [])
@@ -340,6 +384,7 @@ class PaperExecutionService:
                 positions = load_portfolio(str(self.portfolio_file))
                 state["cash"] = max(0.0, self.initial_capital - sum(pos.cost_basis for pos in positions.values()))
         state.setdefault("daily_start_nav", self.initial_capital)
+        state.setdefault("initial_capital", self.initial_capital)
         state.setdefault("manual_halt", False)
         return state
 
@@ -451,7 +496,14 @@ class PaperExecutionService:
         positions = load_portfolio(str(self.portfolio_file))
         nav = float(state.get("cash") or 0.0) + sum(pos.market_value for pos in positions.values())
         daily_start_nav = float(state.get("daily_start_nav") or nav or self.initial_capital)
-        peak_nav = float(state.get("peak_nav") or max(daily_start_nav, nav, self.initial_capital))
+        raw_peak_nav = _positive_float(state.get("peak_nav"))
+        if (
+            raw_peak_nav is not None
+            and raw_peak_nav == self.configured_initial_capital
+            and self.configured_initial_capital > self.initial_capital
+        ):
+            raw_peak_nav = None
+        peak_nav = float(raw_peak_nav or max(daily_start_nav, nav, self.initial_capital))
         state["peak_nav"] = max(peak_nav, nav)
         self._save_state(state)
 

--- a/backend/trading/tui_trading_engine.py
+++ b/backend/trading/tui_trading_engine.py
@@ -68,6 +68,14 @@ LIVE_NAV_LOG_FILE = migrate_legacy_path(TRADING_RUNTIME_DIR / "paper_nav_log.csv
 LIVE_STATE_FILE = migrate_legacy_path(TRADING_RUNTIME_DIR / "paper_state.json", [PROJECT_ROOT / "paper_state.json"])
 
 
+def _positive_float(value) -> Optional[float]:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if number > 0 else None
+
+
 class TUITradingEngine:
     """Self-contained paper trading engine for the TUI dashboard.
 
@@ -100,7 +108,7 @@ class TUITradingEngine:
         on_portfolio_changed: Optional[Callable[[], None]] = None,
         on_agent_updated: Optional[Callable[[], None]] = None,
     ):
-        self.capital = capital
+        self.configured_capital = float(capital)
         self.signal_types = signal_types or list(LONG_TERM_CONFIG["signal_types"])
         self.max_positions = max_positions
         self.holding_days = holding_days
@@ -118,6 +126,7 @@ class TUITradingEngine:
         self.account_id = str(account_id or "account_1")
         self.strategy_id = str(strategy_id or "")
         self.strategy_config = dict(strategy_config or {})
+        self.capital = self._resolve_account_capital(self.configured_capital)
         self._active_run_id = ""
         self._paper_execution = PaperExecutionService(
             self.account_id,
@@ -147,12 +156,18 @@ class TUITradingEngine:
         self._stop_flag: bool = False
         self._prices_df: Optional[pd.DataFrame] = None
         self._consecutive_losses: int = 0
-        self._daily_start_nav: float = capital
+        self._daily_start_nav: float = self.capital
+        self._peak_nav: float = self.capital
         self._halted: bool = False
         self._halt_reason: str = ""
 
         # Load persisted state
         self._load_state()
+        self._peak_nav = max(
+            float(self._peak_nav or 0.0),
+            float(self._daily_start_nav or 0.0),
+            self._calc_nav(),
+        )
 
     # ─── Status helpers ─────────────────────────────────────────────────────
 
@@ -187,6 +202,42 @@ class TUITradingEngine:
         )
 
     # ─── Persistence ────────────────────────────────────────────────────────
+
+    def _resolve_account_capital(self, fallback: float) -> float:
+        """Use the account's seeded NAV when it differs from strategy defaults."""
+        if self._state_file.exists():
+            try:
+                state = json.loads(self._state_file.read_text())
+            except Exception:
+                state = {}
+            if isinstance(state, dict):
+                for key in ("initial_capital", "daily_start_nav"):
+                    value = _positive_float(state.get(key))
+                    if value is not None:
+                        return value
+
+                cash = _positive_float(state.get("cash"))
+                if cash is not None:
+                    try:
+                        has_positions = bool(load_portfolio(str(self._portfolio_file)))
+                        trade_log = pd.read_csv(self._trade_log_file) if self._trade_log_file.exists() else pd.DataFrame()
+                        has_trades = not trade_log.empty
+                    except Exception:
+                        has_positions = has_trades = False
+                    if not has_positions and not has_trades:
+                        return cash
+
+        if self._nav_log_file.exists():
+            try:
+                nav_log = pd.read_csv(self._nav_log_file)
+                if not nav_log.empty and "NAV" in nav_log.columns:
+                    value = _positive_float(nav_log.iloc[0].get("NAV"))
+                    if value is not None:
+                        return value
+            except Exception:
+                pass
+
+        return float(fallback)
 
     def _load_state(self) -> None:
         """Resume from saved state, or bootstrap from existing paper portfolio."""
@@ -238,6 +289,12 @@ class TUITradingEngine:
                 self._last_signal_date = s.get("last_signal_date", "")
                 self._consecutive_losses = s.get("consecutive_losses", 0)
                 self._daily_start_nav = s.get("daily_start_nav", self.capital)
+                self._peak_nav = s.get("peak_nav", self._daily_start_nav or self.capital)
+                if (
+                    float(self._peak_nav or 0.0) == self.configured_capital
+                    and self.configured_capital > self.capital
+                ):
+                    self._peak_nav = max(float(self._daily_start_nav or 0.0), self._calc_nav(), self.capital)
                 self._eod_logged_date = s.get("eod_logged_date", "")
             except Exception:
                 pass
@@ -267,9 +324,11 @@ class TUITradingEngine:
         save_portfolio(self.positions, str(self._portfolio_file))
         state = {
             "cash": round(self.cash, 2),
+            "initial_capital": round(self.capital, 2),
             "last_signal_date": self._last_signal_date,
             "consecutive_losses": self._consecutive_losses,
             "daily_start_nav": round(self._daily_start_nav, 2),
+            "peak_nav": round(max(float(self._peak_nav or 0.0), self._calc_nav()), 2),
             "eod_logged_date": self._eod_logged_date,
             "timestamp": time.time(),
         }
@@ -632,6 +691,7 @@ class TUITradingEngine:
     def _check_kill_switch(self) -> None:
         """Halt trading if risk limits breached."""
         nav = self._calc_nav()
+        self._peak_nav = max(float(self._peak_nav or 0.0), nav, float(self._daily_start_nav or 0.0), self.capital)
 
         # Daily loss check (3%)
         if self._daily_start_nav > 0:
@@ -640,8 +700,8 @@ class TUITradingEngine:
                 self._halt("daily loss > 3%")
                 return
 
-        # Drawdown from capital (15%)
-        dd = (nav - self.capital) / self.capital
+        # Drawdown from the account peak NAV (15%).
+        dd = (nav - self._peak_nav) / self._peak_nav if self._peak_nav > 0 else 0.0
         if dd < -0.15:
             self._halt("drawdown > 15%")
             return

--- a/tests/unit/test_issue26_account_and_kalimati.py
+++ b/tests/unit/test_issue26_account_and_kalimati.py
@@ -1,0 +1,142 @@
+import json
+
+import pandas as pd
+
+from backend.market.kalimati_market import _rows_from_api_payload
+from backend.trading.paper_execution import PaperExecutionService
+from backend.trading.tui_trading_engine import TUITradingEngine
+from apps.tui import dashboard_tui
+
+
+def test_paper_execution_uses_account_seed_nav_for_drawdown_baseline(tmp_path, monkeypatch):
+    state_path = tmp_path / "paper_state.json"
+    state_path.write_text(json.dumps({"cash": 500_000.0, "daily_start_nav": 500_000.0}))
+
+    service = PaperExecutionService(
+        "account_2",
+        account_dir=tmp_path,
+        initial_capital=1_000_000.0,
+        max_positions=5,
+    )
+
+    result = service.submit_order(
+        "account_2",
+        "BUY",
+        "NABIL",
+        10,
+        100.0,
+        "test",
+        "manual",
+    )
+
+    assert service.initial_capital == 500_000.0
+    assert result.ok
+    assert result.risk_result["reason"] == "accepted"
+
+
+def test_tui_engine_does_not_halt_seeded_smaller_account_against_global_default(tmp_path):
+    state_path = tmp_path / "paper_state.json"
+    state_path.write_text(json.dumps({"cash": 500_000.0, "daily_start_nav": 500_000.0}))
+    pd.DataFrame(columns=["Date", "Cash", "Positions_Value", "NAV", "Num_Positions"]).to_csv(
+        tmp_path / "paper_nav_log.csv",
+        index=False,
+    )
+
+    engine = TUITradingEngine(
+        capital=1_000_000.0,
+        portfolio_file=tmp_path / "paper_portfolio.csv",
+        trade_log_file=tmp_path / "paper_trade_log.csv",
+        nav_log_file=tmp_path / "paper_nav_log.csv",
+        state_file=state_path,
+        account_id="account_2",
+    )
+    engine._check_kill_switch()
+
+    assert engine.capital == 500_000.0
+    assert not engine._halted
+
+
+def test_kalimati_daily_prices_api_payload_is_parsed():
+    rows = _rows_from_api_payload(
+        {
+            "status": 200,
+            "date": "2026-05-26",
+            "prices": [
+                {
+                    "commodityname": "Tomato Big(Nepali)",
+                    "commodityunit": "KG",
+                    "minprice": "60.00",
+                    "maxprice": "70.00",
+                    "avgprice": "65.00",
+                }
+            ],
+        }
+    )
+
+    assert rows == [
+        {
+            "name_nepali": "Tomato Big(Nepali)",
+            "name_english": "Tomato Big(Nepali)",
+            "unit_nepali": "KG",
+            "unit_english": "KG",
+            "min": 60.0,
+            "max": 70.0,
+            "avg": 65.0,
+            "date": "2026-05-26",
+        }
+    ]
+
+
+def test_account_seed_state_records_seed_nav_as_initial_capital():
+    state, _ = dashboard_tui._build_account_seed_state(
+        pd.DataFrame(columns=dashboard_tui.PORTFOLIO_COLS),
+        500_000.0,
+    )
+
+    assert state["cash"] == 500_000.0
+    assert state["daily_start_nav"] == 500_000.0
+    assert state["initial_capital"] == 500_000.0
+
+
+def test_profile_snapshot_uses_current_marked_account_nav(tmp_path):
+    account_dir = tmp_path
+    pd.DataFrame(
+        [
+            {
+                "Entry_Date": "2026-05-20",
+                "Symbol": "NABIL",
+                "Quantity": 10,
+                "Buy_Price": 20.0,
+                "Buy_Amount": 200.0,
+                "Buy_Fees": 0.0,
+                "Total_Cost_Basis": 200.0,
+                "Signal_Type": "manual",
+                "High_Watermark": 20.0,
+                "Last_LTP": 20.0,
+                "Last_LTP_Source": "test",
+                "Last_LTP_Time_UTC": "",
+            }
+        ],
+        columns=dashboard_tui.PORTFOLIO_COLS,
+    ).to_csv(account_dir / "paper_portfolio.csv", index=False)
+    pd.DataFrame(columns=dashboard_tui.TRADE_LOG_COLS).to_csv(account_dir / "paper_trade_log.csv", index=False)
+    pd.DataFrame(
+        [{"Date": "2026-05-20", "Cash": 100.0, "Positions_Value": 200.0, "NAV": 999.0, "Num_Positions": 1}],
+        columns=dashboard_tui.NAV_LOG_COLS,
+    ).to_csv(account_dir / "paper_nav_log.csv", index=False)
+    (account_dir / "paper_state.json").write_text(
+        json.dumps({"cash": 100.0, "daily_start_nav": 300.0, "initial_capital": 300.0})
+    )
+
+    class FakeMD:
+        quotes = pd.DataFrame()
+
+        def ltps(self):
+            return {"NABIL": 25.0}
+
+    app = dashboard_tui.NepseDashboard.__new__(dashboard_tui.NepseDashboard)
+    app.md = FakeMD()
+    snapshot = dashboard_tui.NepseDashboard._profile_runtime_snapshot(app, account_dir=account_dir)
+
+    assert snapshot["cash"] == 100.0
+    assert snapshot["nav"] == 350.0


### PR DESCRIPTION
## Summary
- Use each paper account seeded NAV as the account initial capital for NAV, max drawdown, turnover, and kill-switch calculations.
- Keep account list and portfolio header NAV values aligned with current marked portfolio state.
- Load Kalimati commodity prices from the current daily-prices JSON endpoint, with the existing HTML scraper retained as fallback.

## Root Cause
Account-level risk code fell back to the global 1,000,000 default even when an account was seeded with a lower NAV. Kalimati also depended on an older page path before the current JSON endpoint.

## Validation
- python3 -m py_compile apps/tui/dashboard_tui.py backend/trading/paper_execution.py backend/trading/tui_trading_engine.py backend/market/kalimati_market.py tests/unit/test_issue26_account_and_kalimati.py
- python3 -m pytest tests/unit/test_issue26_account_and_kalimati.py tests/unit/test_paper_execution_service.py tests/unit/test_dashboard_tui_intraday.py::test_build_account_seed_state_uses_mark_value_for_cash -q

Fixes #26
