### PR TITLE
Make OSINT opt-in, fix vendor re-base splicing, document backtest caveats honestly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-#NEPSE Quant Terminal
+# NEPSE Quant Terminal
 
 A terminal-based quantitative trading dashboard for the Nepal Stock Exchange (NEPSE), built with [Textual](https://textual.textualize.io/). Runs entirely in your terminal — no browser, no electron, no cloud dependency.
 
 **Paper trading only.** This terminal simulates trades locally. It does not connect to any broker API.
+
+> ⚠️ **Disclaimer — read this first.** This is an **educational research tool, not financial advice.** It does not connect to a broker and cannot place real orders. The bundled backtest figures are **in-sample / historical** — they come from a parameter sweep, are **not** corrected for the number of strategy variants tried, and the repo ships **no artifact that reproduces them as forward-tested returns.** Treat them as a demonstration of the tooling, not as proof of an edge. Past performance does not indicate future results. Nothing here is a recommendation to buy or sell any security. See [docs/VALIDATION_METHODOLOGY.md](docs/VALIDATION_METHODOLOGY.md).
 
 ---
 
@@ -10,14 +12,14 @@ A terminal-based quantitative trading dashboard for the Nepal Stock Exchange (NE
 
 - **Paper Trading** — full paper portfolio with buy/sell order book, P&L tracking, NAV history, and multi-account support. Seed from your MeroShare holdings CSV or start blank.
 - **Auto Trading Engine** — assigns a quantitative strategy to each account. The engine runs in the background, generates signals every 5 trading days, and manages entries/exits automatically (holding periods, stop losses, trailing stops, regime filters).
-- **Backtesting** — walk-forward validated backtests on 6+ years of NEPSE price data. Ships with C5 baseline: **+88% OOS return, Sharpe 2.2** vs. NEPSE +27%.
+- **Backtesting** — backtests on 6+ years of NEPSE price data, with a walk-forward replay harness and a statistical validation suite. The bundled C5 baseline shows a *historical, in-sample* +88% return (Sharpe ~2.2) vs. NEPSE +27% — a figure from a parameter sweep, **not corrected for multiple testing and not a forward-performance claim** (the repo ships no artifact reproducing it). Run the validation suite (deflated Sharpe, random-baseline percentile, CSCV/PBO) to see how it holds up; see [docs/VALIDATION_METHODOLOGY.md](docs/VALIDATION_METHODOLOGY.md).
 - **Market Dashboard** — live quotes, 52-week highs/lows, top movers, sector heatmap, volume signals.
 - **Portfolio Analytics** — unrealized/realized P&L, sector concentration, holding age buckets, max drawdown, alpha vs. NEPSE benchmark.
 - **Gold Hedge Overlay** — tracks gold/silver regime (risk-on / neutral / risk-off) and adjusts capital deployment accordingly.
 - **AI Agent** — on-demand analysis of your portfolio positions and signal shortlist. Defaults to a local Ollama model, with Gemma 4 MLX or Claude CLI available as optional backends.
 - **Paper Agent Graph** — cleaned evidence-gated research, debate, risk, and portfolio decision workflow for paper execution only.
 - **Strategy Builder** — create, backtest, and assign custom strategies. Each account runs its own strategy independently.
-- **Statistical Validation** — walk-forward OOS testing, Monte Carlo, CSCV/PBO overfitting detection, deflated Sharpe ratio, random baseline percentile.
+- **Statistical Validation** — walk-forward replay across rolling subwindows, Monte Carlo, CSCV/PBO overfitting detection, deflated Sharpe ratio, random baseline percentile. See [docs/VALIDATION_METHODOLOGY.md](docs/VALIDATION_METHODOLOGY.md) for what each test does and does not prove.
 - **MeroShare Import** — seed any account directly from your MeroShare "My Shares Values.csv" export.
 
 ---
@@ -66,7 +68,7 @@ The public agent workflow is evidence-gated, checkpointed, and restricted to pap
 | Gold Hedge | `backend/quant_pro/gold_hedge.py` | Gold/silver regime detection → capital deployment % |
 | AI Agent | `backend/agents/agent_analyst.py` | Ollama-first portfolio and signal analysis |
 | Paper Agent Graph | `backend/nepse_agents/` | Evidence-gated research/debate/risk/portfolio workflow; paper-only |
-| NEPSE Calendar | `nepse_calendar.py` | Sun–Thu trading days, public holidays, trading day counter |
+| NEPSE Calendar | `backend/quant_pro/nepse_calendar.py` | Trading-day week (Mon–Fri default), public holidays, trading day counter |
 
 ---
 
@@ -124,6 +126,8 @@ The engine runs a **5-trading-day signal cycle** — signals fire every 5 days, 
 from backend.backtesting.simple_backtest import run_backtest
 
 results = run_backtest(
+    start_date="2020-01-01",   # required
+    end_date="2025-12-31",     # required
     signal_types=["volume", "quality", "low_vol", "mean_reversion",
                   "xsec_momentum", "quarterly_fundamental"],
     holding_days=40,
@@ -135,13 +139,32 @@ results = run_backtest(
 )
 ```
 
-Walk-forward validation splits 6+ years of history into rolling train/test windows and stitches OOS equity:
+The walk-forward phase slides a train/test window across 6+ years of history, re-runs the backtest on each rolling test window, and stitches the out-of-sample equity curves together. Note: it **replays a fixed config** on each window — it does not re-select or re-fit parameters per window, so it is a robustness check, not true out-of-sample model selection. See [docs/VALIDATION_METHODOLOGY.md](docs/VALIDATION_METHODOLOGY.md).
 
 ```bash
 python -m validation.run_all --fast
 ```
 
-Outputs: OOS equity curve, Sharpe, max drawdown, CSCV/PBO score, deflated Sharpe ratio, random baseline percentile.
+Outputs: stitched OOS equity curve, Sharpe, max drawdown, CSCV/PBO score, deflated Sharpe ratio, random baseline percentile.
+
+### Validating the shipped strategy
+
+The validation suite validates the bundled 6-signal C5 baseline (`configs/long_term.py` `LONG_TERM_CONFIG`) by default — the same strategy the auto-trading engine ships with — so the headline figure and the validated strategy are the same thing:
+
+```bash
+python -m validation.run_all          # full battery, C5 baseline
+python -m validation.run_all --fast   # quick mode (fewer simulations)
+```
+
+To validate a different strategy, override the config or individual parameters:
+
+```bash
+python -m validation.run_all --config legacy                 # old 3-signal volume/quality/low_vol config
+python -m validation.run_all --signals volume quality        # ad-hoc signal set
+python -m validation.run_all --holding-days 60               # override one parameter on top of C5
+```
+
+The suite prints a GO / NO-GO verdict and writes a JSON + PDF report under `reports/validation/`. The GO verdict is gated on a subset of the tests (base backtest, transaction costs, statistical significance, walk-forward, Monte Carlo, regime stress, sensitivity, random baseline, slippage, max drawdown). **The CSCV/PBO overfitting test and the benchmark (alpha-vs-beta) comparison run and report, but do not gate the verdict** — read them anyway. See [docs/VALIDATION_METHODOLOGY.md](docs/VALIDATION_METHODOLOGY.md) for what each test does and does not prove.
 
 ---
 
@@ -255,7 +278,7 @@ Takes under a minute. You get 456K rows of OHLCV history for all NEPSE symbols, 
 
 > **Important:** The bundled database is a snapshot. For accurate signals and backtests you must keep it up to date with fresh scraped data. The pre-built DB covers history through the release date — anything after that requires running the scraper.
 
-**Scrape fresh data yourself (recommended for production use):**
+**Scrape fresh data yourself (to keep the snapshot current):**
 ```bash
 python setup_data.py --scrape           # full historical scrape from Merolagani (~30–60 min)
 python setup_data.py --scrape --days 90 # last 90 days only (~5 min)
@@ -457,7 +480,7 @@ nepse-quant-terminal/
 │       ├── regime_detection.py     # Market regime classifier
 │       └── paths.py                # Project path utilities
 ├── configs/
-│   └── long_term.py            # Default strategy parameters
+│   └── long_term.py            # Default strategy parameters (C5 baseline)
 ├── data/
 │   └── strategy_registry/      # Strategy JSON configs
 ├── validation/                 # Statistical validation suite
@@ -466,19 +489,30 @@ nepse-quant-terminal/
 │   ├── cscv_pbo.py
 │   ├── statistical_tests.py
 │   └── run_all.py
-├── nepse_calendar.py           # NEPSE trading calendar (Sun–Thu)
 └── requirements.txt
 ```
+
+The NEPSE trading calendar lives at `backend/quant_pro/nepse_calendar.py`.
 
 ---
 
 ## Notes
 
 - **Paper trading only.** No broker API. All trades are simulated locally.
-- NEPSE trades **Sunday–Thursday**. The calendar module handles all public holidays.
+- NEPSE trades **Monday–Friday** by default (it switched from Sunday–Thursday in April 2026). Set `NEPSE_TRADING_WEEK=sun_thu` to use the legacy calendar. The calendar module handles public holidays.
 - Holding periods are in **trading days**, not calendar days. 40 trading days ≈ 8 NEPSE weeks.
 - The backtest includes realistic transaction costs: SEBON levy, broker commission, DP charges.
 - The gold hedge module uses Nepal Rastra Bank gold price data — no external API required.
+
+### Backtest caveats (read before trusting any return figure)
+
+The base backtest engine is intentionally simple, and these limitations inflate headline returns:
+
+- **No slippage in the base engine.** `run_backtest` charges fees but fills at the open with zero slippage. Slippage is only estimated in a separate validation phase (`validation/slippage.py`); the +88% figure does not include it.
+- **Circuit-locked days fill at the band.** Entry prices are clamped to the ±10% circuit limit (`apply_circuit_breaker`), so a day where a stock is limit-locked still "fills" at the band — a price you often could not actually transact at on a thin NEPSE name.
+- **Survivorship bias.** The universe is the set of symbols currently in the bundled database (a static snapshot). Delisted/suspended names are not reconstructed point-in-time, which biases historical results upward.
+
+Run `python -m validation.run_all` and read the deflated Sharpe, random-baseline percentile, and benchmark (alpha vs. beta) outputs rather than the headline return. See [docs/VALIDATION_METHODOLOGY.md](docs/VALIDATION_METHODOLOGY.md).
 
 ---
 

--- a/apps/mcp/server.py
+++ b/apps/mcp/server.py
@@ -19,11 +19,23 @@ from backend.agents.runtime_config import (
     set_active_agent,
 )
 from backend.nepse_agents import run_paper_decision
-from backend.quant_pro.nepalosint_client import (
-    related_stories as nepalosint_related_stories,
-    semantic_story_search as nepalosint_semantic_story_search,
-    unified_search as nepalosint_unified_search,
-)
+# OSINT enrichment is OPTIONAL in the public build (self-hosted service). Degrade
+# to no-op tools rather than failing to import the MCP server.
+try:
+    from backend.quant_pro.nepalosint_client import (
+        related_stories as nepalosint_related_stories,
+        semantic_story_search as nepalosint_semantic_story_search,
+        unified_search as nepalosint_unified_search,
+    )
+except Exception:  # pragma: no cover - optional dependency
+    def nepalosint_related_stories(*_a, **_k):
+        return []
+
+    def nepalosint_semantic_story_search(*_a, **_k):
+        return []
+
+    def nepalosint_unified_search(*_a, **_k):
+        return {}
 from backend.quant_pro.control_plane.command_service import (
     ControlPlaneCommandService,
     build_env_live_trader_control_plane,

--- a/apps/tui/dashboard_tui.py
+++ b/apps/tui/dashboard_tui.py
@@ -1995,7 +1995,7 @@ def _ensure_lookup_history(symbol: str, *, min_sessions: int = 2, history_days: 
         start_ts = int((datetime.now() - timedelta(days=max(30, int(history_days)))).timestamp())
         fetched = fetch_ohlcv_chunk(sym, start_ts=start_ts, end_ts=end_ts)
         if fetched is not None and not fetched.empty:
-            save_to_db(fetched, sym)
+            save_to_db(fetched, sym, on_rebase="abort")
             return int(len(fetched))
     except Exception:
         return current_count

--- a/apps/tui/dashboard_tui.py
+++ b/apps/tui/dashboard_tui.py
@@ -1046,7 +1046,9 @@ def _merge_tms_bundle_with_cache(bundle: Optional[dict]) -> dict:
 TICKER_SPEED = 0.15  # seconds between scroll steps
 
 # ── OSINT API ────────────────────────────────────────────────────────────────
-OSINT_BASE = "http://3.148.250.92/api/v1"
+# Optional, self-hosted OSINT enrichment service. Disabled by default in the
+# public build — set NEPSE_OSINT_BASE to your own endpoint to enable it.
+OSINT_BASE = os.environ.get("NEPSE_OSINT_BASE", "").rstrip("/")
 OSINT_TIMEOUT = 8
 
 SEVERITY_STYLE = {
@@ -1210,7 +1212,9 @@ def _truncate_text(text: str, width: int) -> str:
 
 
 def _fetch_osint_stories(limit: int = 40) -> list[dict]:
-    """Fetch latest stories from Nepal OSINT API."""
+    """Fetch latest stories from Nepal OSINT API (disabled unless configured)."""
+    if not OSINT_BASE:
+        return []
     try:
         r = _requests.get(f"{OSINT_BASE}/analytics/consolidated-stories",
                           params={"limit": limit}, timeout=OSINT_TIMEOUT)
@@ -1220,7 +1224,9 @@ def _fetch_osint_stories(limit: int = 40) -> list[dict]:
         return []
 
 def _fetch_osint_brief() -> dict:
-    """Fetch latest intelligence brief."""
+    """Fetch latest intelligence brief (disabled unless configured)."""
+    if not OSINT_BASE:
+        return {}
     try:
         r = _requests.get(f"{OSINT_BASE}/briefs/latest", timeout=OSINT_TIMEOUT)
         r.raise_for_status()
@@ -5876,6 +5882,8 @@ class NepseDashboard(App):
         self.call_from_thread(self._set_status, f"Vector search: \"{query}\"...")
         vector_ok = False
         try:
+            if not OSINT_BASE:
+                raise RuntimeError("OSINT disabled")  # fall through to local search
             r = _requests.post(
                 f"{OSINT_BASE}/embeddings/search",
                 json={"query": query, "top_k": 40, "hours": 8760, "min_similarity": 0.3},

--- a/backend/agents/agent_analyst.py
+++ b/backend/agents/agent_analyst.py
@@ -34,14 +34,36 @@ from backend.agents.runtime_config import (
 )
 from backend.quant_pro.nepse_calendar import current_nepal_datetime, get_market_schedule, market_session_phase
 from backend.quant_pro.control_plane.models import AgentDecision
-from backend.quant_pro.nepalosint_client import (
-    consolidated_stories,
-    consolidated_stories_history,
-    resolve_osint_base_url,
-    semantic_story_search,
-    symbol_intelligence,
-    unified_search,
-)
+# OSINT enrichment is OPTIONAL in the public build. If the self-hosted OSINT
+# client is absent or not configured, the analyst runs without it (no external
+# calls, neutral OSINT bias) rather than failing to import.
+try:
+    from backend.quant_pro.nepalosint_client import (
+        consolidated_stories,
+        consolidated_stories_history,
+        resolve_osint_base_url,
+        semantic_story_search,
+        symbol_intelligence,
+        unified_search,
+    )
+except Exception:  # pragma: no cover - optional dependency
+    def resolve_osint_base_url(*_a, **_k) -> str:
+        return ""
+
+    def consolidated_stories(*_a, **_k):
+        return []
+
+    def consolidated_stories_history(*_a, **_k):
+        return []
+
+    def semantic_story_search(*_a, **_k):
+        return []
+
+    def symbol_intelligence(*_a, **_k):
+        return {}
+
+    def unified_search(*_a, **_k):
+        return {}
 from backend.quant_pro.paths import ensure_dir, get_project_root, get_runtime_dir, migrate_legacy_path
 from backend.quant_pro.signal_ranking import canonicalize_signal_symbol
 from backend.trading import strategy_registry

--- a/backend/quant_pro/corporate_actions.py
+++ b/backend/quant_pro/corporate_actions.py
@@ -6,7 +6,7 @@ https://merolagani.com/CompanyDetail.aspx?symbol=SYMBOL
 
 Design goals:
 - Robust parsing across minor HTML/layout changes
-- Idempotent persistence into SQLite (see database_extended.py helpers)
+- Idempotent persistence into SQLite (see database.py schema helpers)
 - Explicit, explainable outputs suitable for UI display
 """
 
@@ -22,7 +22,7 @@ import sqlite3
 import requests
 from bs4 import BeautifulSoup
 
-from .database import get_db_connection
+from .database import get_db_connection, _ensure_corporate_actions_schema
 
 
 MEROLAGANI_BASE = "https://merolagani.com"
@@ -228,30 +228,32 @@ def parse_corporate_actions_from_company_detail_html(
 
 def ensure_corporate_actions_tables(conn: sqlite3.Connection) -> None:
     """
-    Keep the DDL close to the ingestion logic for robustness.
-    database_extended.py calls a similar helper; this is used by callers that
-    don’t import the extended schema module.
+    Ensure the unified corporate_actions table exists.
+
+    The canonical (schema-A) table is created by ``database.init_db``; this keeps
+    the same base DDL for callers that haven't run init_db, then delegates the
+    extra scraper columns to the single source of truth in database.py.
     """
     cur = conn.cursor()
     cur.execute(
         """
         CREATE TABLE IF NOT EXISTS corporate_actions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
             symbol TEXT NOT NULL,
             fiscal_year TEXT,
             bookclose_date DATE,
-            description TEXT,
-            agenda TEXT,
-            cash_dividend_pct REAL,
-            bonus_share_pct REAL,
+            cash_dividend_pct REAL DEFAULT 0,
+            bonus_share_pct REAL DEFAULT 0,
             right_share_ratio TEXT,
-            source_url TEXT,
-            scraped_at_utc TEXT NOT NULL,
-            PRIMARY KEY (symbol, fiscal_year, bookclose_date, description)
+            agenda TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(symbol, bookclose_date)
         )
         """
     )
     cur.execute("CREATE INDEX IF NOT EXISTS idx_corp_actions_symbol ON corporate_actions(symbol)")
     cur.execute("CREATE INDEX IF NOT EXISTS idx_corp_actions_bookclose ON corporate_actions(bookclose_date)")
+    _ensure_corporate_actions_schema(cur)
 
 
 def upsert_corporate_actions(rows: List[CorporateActionRow]) -> int:
@@ -260,6 +262,13 @@ def upsert_corporate_actions(rows: List[CorporateActionRow]) -> int:
     conn = get_db_connection()
     ensure_corporate_actions_tables(conn)
     cur = conn.cursor()
+    # SQLite treats NULLs as distinct in UNIQUE(symbol, bookclose_date), so
+    # clear prior NULL-bookclose rows per symbol to keep rescrapes idempotent.
+    for symbol in {r.symbol for r in rows}:
+        cur.execute(
+            "DELETE FROM corporate_actions WHERE symbol = ? AND bookclose_date IS NULL",
+            (symbol,),
+        )
     inserted = 0
     for r in rows:
         cur.execute(
@@ -275,8 +284,8 @@ def upsert_corporate_actions(rows: List[CorporateActionRow]) -> int:
                 r.bookclose_date_ad.isoformat() if r.bookclose_date_ad else None,
                 r.description,
                 r.agenda,
-                r.cash_dividend_pct,
-                r.bonus_share_pct,
+                r.cash_dividend_pct if r.cash_dividend_pct is not None else 0.0,
+                r.bonus_share_pct if r.bonus_share_pct is not None else 0.0,
                 r.right_share_ratio,
                 r.source_url,
                 r.scraped_at_utc.isoformat(),

--- a/backend/quant_pro/data_io.py
+++ b/backend/quant_pro/data_io.py
@@ -15,7 +15,15 @@ from tenacity import (
     before_sleep_log,
 )
 # Ensure .database module is available for init_db, etc.
-from .database import init_db, get_latest_date, save_to_db, load_from_db
+from .database import (
+    init_db,
+    get_latest_date,
+    get_overlap_start_date,
+    save_to_db,
+    load_from_db,
+    register_pending_resync,
+    clear_pending_resync,
+)
 from .vendor_api import _rate_limiter, fetch_latest_ltp
 
 # Configure logging for data_io module
@@ -262,6 +270,23 @@ def fetch_sector_history(sector_symbol: str, duration_days: int = 3650) -> pd.Da
         logger.error(f"Sector {sector_symbol}: Unexpected error: {type(e).__name__}: {e}")
         return pd.DataFrame()
 
+def resync_full_history(symbol: str) -> bool:
+    """Vendor re-based: re-fetch ~10y and rewrite the whole series on the new basis.
+
+    Returns True on a successful rewrite. On a failed fetch the symbol is queued
+    in pending_full_resync for retry and the DB is left untouched (fail-closed).
+    """
+    start = datetime.now() - timedelta(days=365 * 10)
+    df = fetch_chunk(symbol, start.timestamp(), time.time())
+    if df is None or df.empty:
+        register_pending_resync(symbol)
+        return False
+    df = df.drop_duplicates(subset=["Date"], keep="last")
+    save_to_db(df, symbol, on_rebase="log", log_reason="full_resync")
+    clear_pending_resync(symbol)
+    return True
+
+
 def _fetch_dynamic_data(symbol: str) -> pd.DataFrame:
     """
     ROBUST DATA SYNCHRONIZATION LOGIC.
@@ -284,7 +309,10 @@ def _fetch_dynamic_data(symbol: str) -> pd.DataFrame:
     # --- STEP 2: Incremental Update ---
     elif last_date < today:
         with _spinner_context(f"Fetching updates since {last_date}..."):
-            start_ts = pd.Timestamp(last_date).timestamp()
+            # Widen the window to overlap the last few stored bars so a vendor
+            # re-base is detectable; this adds no extra HTTP requests.
+            overlap_start = get_overlap_start_date(symbol, 5) or last_date
+            start_ts = pd.Timestamp(overlap_start).timestamp()
             new_data = fetch_chunk(symbol, start_ts, time.time())
         
     # --- STEP 3: Live Candle (Today's Price) ---
@@ -295,7 +323,15 @@ def _fetch_dynamic_data(symbol: str) -> pd.DataFrame:
 
     if not new_data.empty:
         new_data = new_data.drop_duplicates(subset=["Date"], keep="last")
-        save_to_db(new_data, symbol)
+        if last_date is None:
+            # STEP 1 full fetch: rewriting the whole series on the new basis is the intent.
+            save_to_db(new_data, symbol, on_rebase="log")
+        else:
+            # STEP 2 incremental: never persist a half-spliced series.
+            result = save_to_db(new_data, symbol, on_rebase="abort")
+            if result.rebase_detected:
+                with _spinner_context(f"{symbol}: vendor re-based history — full re-sync..."):
+                    resync_full_history(symbol)
     elif live_df.empty and last_date is None:
         _report_error(f"Could not fetch any data for {symbol}.")
         return pd.DataFrame()

--- a/backend/quant_pro/database.py
+++ b/backend/quant_pro/database.py
@@ -3,9 +3,10 @@ import logging
 import os
 import sqlite3
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 import pandas as pd
 
@@ -17,6 +18,15 @@ logger = logging.getLogger(__name__)
 
 # Flag to track if WAL mode has been initialized
 _wal_initialized = False
+
+# Tolerances for the save-path re-base detector.
+# LOG_TOL is absolute: unchanged JSON floats reproduce exactly, so anything
+# beyond it is a genuine retro change worth logging.
+# REBASE_RTOL is relative: the smallest real NEPSE events (small rights/bonus)
+# shift prices by >=1%, while float jitter is well under 0.1%, so a relative
+# move beyond REBASE_RTOL classifies a vendor re-base.
+LOG_TOL = 1e-9
+REBASE_RTOL = 1e-3
 
 
 def get_db_path() -> Path:
@@ -90,6 +100,73 @@ def get_db_connection(timeout: float = 60.0, retries: int = 3) -> sqlite3.Connec
     raise DatabaseError(f"Failed to connect after {retries} attempts: {last_err}") from last_err
 
 
+def _ensure_column(cursor: sqlite3.Cursor, table: str, column: str, decl: str) -> bool:
+    """Add ``column`` to ``table`` if missing (SQLite has no IF NOT EXISTS on
+    ADD COLUMN). Returns True iff the column was added by this call."""
+    have = {row[1] for row in cursor.execute(f"PRAGMA table_info({table})")}
+    if column not in have:
+        cursor.execute(f"ALTER TABLE {table} ADD COLUMN {column} {decl}")
+        return True
+    return False
+
+
+def _ensure_price_adjustment_schema(cursor: sqlite3.Cursor) -> None:
+    """Idempotent guard for raw_close + the adjustment audit log + resync queue."""
+    added = _ensure_column(cursor, "stock_prices", "raw_close", "REAL")
+    if added:
+        # One-time eager backfill: best-effort "as first seen" = current stored close.
+        cursor.execute("UPDATE stock_prices SET raw_close = close WHERE raw_close IS NULL")
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS price_adjustment_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            symbol TEXT NOT NULL,
+            date DATE NOT NULL,
+            old_close REAL,
+            new_close REAL,
+            ratio REAL,
+            reason TEXT NOT NULL DEFAULT 'resave',
+            detected_at_utc TEXT NOT NULL
+        )
+    ''')
+    cursor.execute('''
+        CREATE INDEX IF NOT EXISTS idx_price_adjustment_log_symbol
+        ON price_adjustment_log (symbol, date)
+    ''')
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS pending_full_resync (
+            symbol TEXT PRIMARY KEY,
+            first_detected_at_utc TEXT NOT NULL,
+            last_attempt_utc TEXT,
+            attempts INTEGER NOT NULL DEFAULT 0
+        )
+    ''')
+
+
+def _ensure_corporate_actions_schema(cursor: sqlite3.Cursor) -> None:
+    """Idempotent guard unifying the corporate_actions schema onto a superset.
+
+    The base table (schema A) is created by ``init_db``; this adds the extra
+    columns the scraper writes. For DBs whose table was created standalone by the
+    scraper (schema B), these calls are no-ops and the schema-A-only columns are
+    backfilled instead — both ancestries converge on a working superset.
+    """
+    _ensure_column(cursor, "corporate_actions", "description", "TEXT")
+    _ensure_column(cursor, "corporate_actions", "source_url", "TEXT")
+    _ensure_column(cursor, "corporate_actions", "scraped_at_utc", "TEXT")
+    _ensure_column(cursor, "corporate_actions", "cash_dividend_pct", "REAL DEFAULT 0")
+    _ensure_column(cursor, "corporate_actions", "bonus_share_pct", "REAL DEFAULT 0")
+    _ensure_column(cursor, "corporate_actions", "right_share_ratio", "TEXT")
+    _ensure_column(cursor, "corporate_actions", "agenda", "TEXT")
+    _ensure_column(cursor, "corporate_actions", "fiscal_year", "TEXT")
+
+
+@dataclass
+class SaveResult:
+    rows_saved: int = 0
+    retro_changes: int = 0        # rows whose stored close differed beyond LOG_TOL
+    rebase_detected: bool = False  # any row beyond REBASE_RTOL -> vendor re-based
+
+
 def _dedupe_stock_prices(cursor: sqlite3.Cursor) -> None:
     """Keep the newest row for each legacy duplicate (symbol, date) pair."""
     cursor.execute(
@@ -134,6 +211,7 @@ def init_db():
             PRIMARY KEY (symbol, date)
         )
     ''')
+    _ensure_price_adjustment_schema(cursor)
     _dedupe_stock_prices(cursor)
     cursor.execute('''
         CREATE UNIQUE INDEX IF NOT EXISTS idx_stock_prices_symbol_date_unique
@@ -169,6 +247,7 @@ def init_db():
         CREATE INDEX IF NOT EXISTS idx_corporate_actions_symbol
         ON corporate_actions (symbol)
     ''')
+    _ensure_corporate_actions_schema(cursor)
 
     # Raw intraday market snapshots for audit/replay of upstream payloads.
     cursor.execute(
@@ -557,9 +636,87 @@ def get_latest_date(symbol):
     conn.close()
     return pd.to_datetime(result).date() if result else None
 
-def save_to_db(df, symbol):
-    """Saves new data to SQLite, ignoring duplicates."""
-    if df.empty: return
+
+def get_overlap_start_date(symbol: str, n_bars: int = 5) -> Optional[str]:
+    """Date of the n_bars-th most recent stored bar (falls back to the oldest
+    stored bar when fewer exist), or None when the symbol has no rows.
+
+    Used to widen the incremental fetch window so the re-base detector always has
+    overlapping bars to compare; it adds no extra HTTP requests.
+    """
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    cursor.execute("SELECT COUNT(*) FROM stock_prices WHERE symbol = ?", (symbol,))
+    count = int(cursor.fetchone()[0] or 0)
+    if count == 0:
+        conn.close()
+        return None
+    offset = min(n_bars - 1, count - 1)
+    cursor.execute(
+        "SELECT date FROM stock_prices WHERE symbol = ? ORDER BY date DESC LIMIT 1 OFFSET ?",
+        (symbol, offset),
+    )
+    row = cursor.fetchone()
+    conn.close()
+    return str(row[0]) if row and row[0] is not None else None
+
+
+def register_pending_resync(symbol: str) -> None:
+    """Queue ``symbol`` for a full-history re-fetch (UPSERT, bump attempts)."""
+    now_iso = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    _ensure_price_adjustment_schema(cursor)
+    cursor.execute(
+        '''
+        INSERT INTO pending_full_resync (symbol, first_detected_at_utc, last_attempt_utc, attempts)
+        VALUES (?, ?, ?, 1)
+        ON CONFLICT(symbol) DO UPDATE SET
+            last_attempt_utc = excluded.last_attempt_utc,
+            attempts = attempts + 1
+        ''',
+        (symbol, now_iso, now_iso),
+    )
+    conn.commit()
+    conn.close()
+
+
+def clear_pending_resync(symbol: str) -> None:
+    """Remove ``symbol`` from the full-history re-fetch queue."""
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    _ensure_price_adjustment_schema(cursor)
+    cursor.execute("DELETE FROM pending_full_resync WHERE symbol = ?", (symbol,))
+    conn.commit()
+    conn.close()
+
+
+def list_pending_resyncs() -> List[str]:
+    """Return symbols currently queued for a full-history re-fetch."""
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    _ensure_price_adjustment_schema(cursor)
+    cursor.execute("SELECT symbol FROM pending_full_resync ORDER BY symbol ASC")
+    rows = cursor.fetchall()
+    conn.close()
+    return [str(r[0]) for r in rows]
+
+def save_to_db(df, symbol, *, on_rebase: str = "log", log_reason: str = "resave") -> "SaveResult":
+    """Save OHLCV rows, preserving first-seen ``raw_close`` and auditing changes.
+
+    Every re-save is compared against the stored close: changes beyond ``LOG_TOL``
+    are recorded in ``price_adjustment_log``; a relative change beyond
+    ``REBASE_RTOL`` flags a vendor re-base.
+
+    ``on_rebase``:
+        ``"log"`` (default) — rewrite every row on the new basis (the intent of a
+        full-history save) and log the changes.
+        ``"abort"`` — when a re-base is detected, write no price rows; only the
+        detection evidence is persisted (``reason='rebase_overlap'``). The DB
+        stays on a single (old) basis until a full re-fetch replaces it.
+    """
+    if df.empty:
+        return SaveResult()
 
     conn = get_db_connection()
     df = df.copy()
@@ -578,7 +735,7 @@ def save_to_db(df, symbol):
             df = df.loc[~bad].copy()
             if df.empty:
                 conn.close()
-                return
+                return SaveResult()
     except (KeyError, ValueError, TypeError) as exc:
         logger.debug("Data hygiene check skipped: %s", exc)
 
@@ -586,15 +743,98 @@ def save_to_db(df, symbol):
     df_to_save = df[["symbol", "date", "Open", "High", "Low", "Close", "Volume"]]
     df_to_save.columns = ["symbol", "date", "open", "high", "low", "close", "volume"]
 
-    # Efficient Upsert (Insert or Ignore)
     cursor = conn.cursor()
+    _ensure_price_adjustment_schema(cursor)
+    # Commit the migration before any data work: the abort path rolls back the
+    # transaction, and the DDL must not be undone with it on a first-run DB.
+    conn.commit()
+
+    # Pre-read existing rows for the incoming dates so we can preserve raw_close
+    # (first-seen close) and compare against the new basis.
+    incoming_dates = list(df_to_save["date"])
+    existing: Dict[str, tuple] = {}
+    if incoming_dates:
+        placeholders = ",".join("?" for _ in incoming_dates)
+        cursor.execute(
+            f'''
+            SELECT date, close, raw_close FROM stock_prices
+            WHERE symbol = ? AND date IN ({placeholders})
+            ''',
+            [symbol, *incoming_dates],
+        )
+        for row in cursor.fetchall():
+            existing[str(row[0])] = (row[1], row[2])
+
+    now_iso = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    rows: List[tuple] = []
+    adjustments: List[tuple] = []
+    retro_changes = 0
+    rebase_detected = False
+
+    for r in df_to_save.itertuples(index=False):
+        new_close = r.close
+        prior = existing.get(r.date)
+        if prior is not None:
+            old_close, old_raw = prior
+            # Lazy first-seen preservation/backfill.
+            raw_close = old_raw if old_raw is not None else old_close
+            if old_close is not None and abs(old_close - new_close) > LOG_TOL:
+                ratio = (new_close / old_close) if old_close else None
+                adjustments.append(
+                    (symbol, r.date, old_close, new_close, ratio, log_reason, now_iso)
+                )
+                retro_changes += 1
+                if old_close and abs((new_close / old_close) - 1.0) > REBASE_RTOL:
+                    rebase_detected = True
+        else:
+            raw_close = new_close
+        rows.append((r.symbol, r.date, r.open, r.high, r.low, new_close, r.volume, raw_close))
+
+    if on_rebase == "abort" and rebase_detected:
+        # Persist no price rows; keep only the detection evidence so the series
+        # stays on one consistent (old) basis until a full re-fetch replaces it.
+        conn.rollback()
+        rebase_log = [
+            (a[0], a[1], a[2], a[3], a[4], "rebase_overlap", a[6]) for a in adjustments
+        ]
+        cursor.executemany(
+            '''
+            INSERT INTO price_adjustment_log (
+                symbol, date, old_close, new_close, ratio, reason, detected_at_utc
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            ''',
+            rebase_log,
+        )
+        conn.commit()
+        conn.close()
+        logger.warning(
+            "%s: vendor re-base detected in overlap (%d rows); aborting incremental save",
+            symbol, len(adjustments),
+        )
+        return SaveResult(rows_saved=0, retro_changes=retro_changes, rebase_detected=True)
+
     cursor.executemany('''
-        INSERT OR REPLACE INTO stock_prices (symbol, date, open, high, low, close, volume)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
-    ''', df_to_save.values.tolist())
+        INSERT OR REPLACE INTO stock_prices (symbol, date, open, high, low, close, volume, raw_close)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    ''', rows)
+
+    if adjustments:
+        cursor.executemany(
+            '''
+            INSERT INTO price_adjustment_log (
+                symbol, date, old_close, new_close, ratio, reason, detected_at_utc
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            ''',
+            adjustments,
+        )
+        logger.warning(
+            "%s: %d stored close(s) changed on re-save (reason=%s)",
+            symbol, len(adjustments), log_reason,
+        )
 
     conn.commit()
     conn.close()
+    return SaveResult(rows_saved=len(rows), retro_changes=retro_changes, rebase_detected=rebase_detected)
 
 def load_from_db(symbol):
     """Loads full history for a symbol."""

--- a/backend/quant_pro/nepalosint_client.py
+++ b/backend/quant_pro/nepalosint_client.py
@@ -1,8 +1,12 @@
 """
 NepalOSINT API client for semantic and unified search.
 
-NOTE: The NepalOSINT API endpoints used here are not publicly accessible.
-Access is restricted — contact @nlethetech on X (Twitter) to request API access.
+NOTE: This OSINT enrichment service is OPTIONAL and self-hosted. It is disabled
+by default in the public build — no base URL is configured, so every function
+degrades gracefully (empty result, no network call) until you point it at your
+own endpoint. Configure it via the NEPALOSINT_BASE_URL or NEPALOSINT_API_BASE_URL
+environment variable (or pass an explicit base_url argument). An optional
+NEPALOSINT_API_KEY enables authenticated access.
 """
 
 from __future__ import annotations
@@ -16,7 +20,7 @@ from typing import Any
 import requests
 from requests import Timeout
 
-DEFAULT_OSINT_BASE_URL = "https://nepalosint.com/api/v1"
+DEFAULT_OSINT_BASE_URL = ""
 DEFAULT_TIMEOUT_SECONDS = 8
 _TOKEN_CACHE: dict[str, Any] = {"base_url": "", "token": "", "expires_at": 0.0}
 _TOKEN_LOCK = threading.Lock()
@@ -119,6 +123,11 @@ def _request_json(
     timeout: int = DEFAULT_TIMEOUT_SECONDS,
 ) -> Any:
     api_root = resolve_osint_base_url(base_url)
+    if not api_root:
+        # Service is not configured (default in the public build): no base URL
+        # means no network call. Callers catch this and return their neutral
+        # empty result.
+        raise RuntimeError("NepalOSINT base URL is not configured")
     api_key = str(os.environ.get("NEPALOSINT_API_KEY", "")).strip()
     request = requests.get if method.upper() == "GET" else requests.post
 

--- a/backend/trading/live_trader.py
+++ b/backend/trading/live_trader.py
@@ -2470,9 +2470,12 @@ class LiveTrader:
         self.peak_nav: float = self.capital
         self.consecutive_losses: int = 0
 
-        # Telegram
+        # Telegram (optional; live-path only — absent in the paper-only public build)
         if not self.no_telegram:
-            from backend.quant_pro.telegram_alerts import send_alert  # noqa: F401
+            try:
+                from backend.quant_pro.telegram_alerts import send_alert  # noqa: F401
+            except Exception:
+                self.no_telegram = True
 
         if self.tms_monitor_enabled:
             try:

--- a/docs/VALIDATION_METHODOLOGY.md
+++ b/docs/VALIDATION_METHODOLOGY.md
@@ -1,0 +1,112 @@
+# Validation Methodology & Honest Caveats
+
+This document exists so the headline backtest number (**C5 baseline: +88% historical
+return, Sharpe ~2.2 vs NEPSE +27%**) is not read as more than it is.
+
+## What the number is
+
+- **In-sample / historical**, on 6+ years of NEPSE daily price data.
+- Produced by the C5 strategy configuration (`configs/long_term.py`,
+  `LONG_TERM_CONFIG`): ~40 trading-day holding period, max 5 positions, regime
+  filter, stop-loss / trailing-stop exits, realistic transaction costs (SEBON
+  levy, broker commission, DP charge).
+- A figure from a **parameter sweep** — the best-looking configuration out of
+  several that were tried.
+- A demonstration that the **tooling** (backtest engine, walk-forward harness,
+  cost model, regime logic) works end-to-end.
+
+The repo currently ships **no artifact that reproduces +88% as a forward-tested
+or out-of-sample return.** It is an in-sample backtest figure.
+
+## What the number is NOT
+
+- It is **not** corrected for the number of strategy variants that were tried.
+  When many configurations are searched, the best one looks good **by chance**;
+  the honest metric is the **deflated Sharpe ratio**, which adjusts for the
+  number of trials. Always read the deflated Sharpe, not the raw one.
+- It is **not** an out-of-sample or forward-performance claim. Past performance
+  does not indicate future results.
+- It is **not** evidence of a tradeable edge on its own. A high return can be
+  mostly **market beta** (exposure to a rising market), not **alpha** (skill).
+
+## How to check it yourself
+
+The repo ships the tools to pressure-test the claim — use them and believe those
+numbers over the headline. The suite validates the shipped C5 baseline by
+default, so you are testing the same strategy the headline quotes:
+
+```bash
+python -m validation.run_all          # full battery, C5 baseline
+python -m validation.run_all --fast   # quick mode (fewer simulations)
+```
+
+It prints a GO / NO-GO verdict and writes a JSON + PDF report under
+`reports/validation/`. Look specifically at:
+
+- **Deflated Sharpe ratio (DSR)** — Sharpe corrected for multiple testing. If DSR
+  is near zero, the apparent edge is likely noise.
+- **Random-baseline percentile** — where the strategy ranks against thousands of
+  random-entry portfolios run on the same universe and cost model. Below the
+  ~50th percentile means *worse than random*; the suite's GO gate asks for the
+  95th percentile.
+- **CSCV / PBO** — probability of backtest overfitting (Bailey et al.). Reported,
+  but see the gate note below.
+- **Benchmark-relative** — alpha vs. beta against NEPSE; is the return skill or
+  just the market? Reported, but see the gate note below.
+- **Walk-forward** — Sharpe across rolling out-of-sample test windows (see the
+  caveat below on what this harness does and does not do).
+
+### What gates the GO verdict (and what doesn't)
+
+The GO / NO-GO verdict is decided only by a subset of the tests: base backtest,
+transaction costs, statistical significance (PSR/DSR/t-test), walk-forward,
+Monte Carlo, regime stress, sensitivity, random baseline, slippage, and max
+drawdown.
+
+The **CSCV/PBO overfitting test** and the **benchmark (alpha-vs-beta)
+comparison** run and are written to the report, but they **do not gate the
+verdict**. A run can print GO while still showing a high PBO or near-zero alpha.
+Read those two outputs directly — do not rely on the headline verdict to catch
+them.
+
+## Caveats specific to the walk-forward harness
+
+The walk-forward phase (`validation/walk_forward.py`) slides a train/test window
+across the history and stitches the per-window out-of-sample equity curves
+together. It is a **robustness check, not out-of-sample model selection**:
+
+- It **replays a fixed configuration** on each test window. There is **no
+  training step** — parameters are not re-fit or re-selected per window using
+  only that window's training data.
+- The train window only provides context (e.g. regime detection looks back
+  before the test period). It does not search for the best config.
+
+So a strong walk-forward result says the fixed C5 config held up across
+subperiods; it does **not** demonstrate that a fresh model selected on past data
+would have chosen well going forward.
+
+## Known limitations of NEPSE backtesting
+
+These limitations bias historical results upward and are not all corrected in
+the base engine:
+
+- **No slippage in the base engine.** `run_backtest` charges fees but fills at
+  the open with zero slippage. Slippage is only estimated in a separate phase
+  (`validation/slippage.py`); the headline figure does not include it.
+- **Circuit-locked days fill at the band.** Entry prices are clamped to the ±10%
+  circuit limit (`apply_circuit_breaker`), so a day where a name is limit-locked
+  still "fills" at the band — a price you often could not actually transact at on
+  a thin NEPSE stock.
+- **Survivorship bias.** The universe is the set of symbols currently present in
+  the bundled database (a static snapshot). Delisted or suspended names are not
+  reconstructed point-in-time.
+- **Frontier-market microstructure.** ±10% circuit breakers, T+2 settlement, and
+  thin order books mean real execution costs on illiquid names can far exceed
+  modelled slippage.
+- **Point-in-time correctness** must be verified for any fundamental or
+  corporate-action signal — unadjusted prices around bonus issues fabricate
+  returns.
+
+**Bottom line:** treat the bundled backtest as a worked example of the pipeline,
+not as a reason to expect those returns. If you trade real capital, do your own
+out-of-sample validation first.

--- a/scripts/ingestion/deterministic_daily_ingestion.py
+++ b/scripts/ingestion/deterministic_daily_ingestion.py
@@ -26,7 +26,14 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from backend.quant_pro.database import get_db_path, save_to_db
+from backend.quant_pro.database import (
+    get_db_path,
+    get_overlap_start_date,
+    list_pending_resyncs,
+    register_pending_resync,
+    save_to_db,
+)
+from backend.quant_pro.data_io import resync_full_history
 from backend.quant_pro.institutional import (
     INGESTION_RUN_STATUS,
     INGESTION_SYMBOL_STATUS,
@@ -264,7 +271,16 @@ def fetch_symbol_history(
     if latest_before is None:
         start_dt = datetime.now() - timedelta(days=history_days)
     else:
-        start_dt = pd.Timestamp(latest_before).to_pydatetime() - timedelta(days=backfill_days)
+        # Overlap the last N stored bars so a vendor re-base is detectable; keep
+        # --backfill-days as a calendar floor for back-compat. Use whichever
+        # window reaches further back.
+        backfill_floor = pd.Timestamp(latest_before).to_pydatetime() - timedelta(days=backfill_days)
+        overlap_start = get_overlap_start_date(symbol, 5)
+        if overlap_start is not None:
+            overlap_dt = pd.Timestamp(overlap_start).to_pydatetime()
+            start_dt = min(backfill_floor, overlap_dt)
+        else:
+            start_dt = backfill_floor
     start_ts = int(start_dt.timestamp())
     df = fetch_ohlcv_chunk(symbol, start_ts=start_ts, end_ts=now_ts)
     if df is None or df.empty:
@@ -298,6 +314,7 @@ def execute_ingestion(
     max_staleness_days: int,
     sleep_ms: int,
     strict: bool,
+    max_full_resyncs: int = 25,
 ) -> int:
     signal.signal(signal.SIGINT, _handle_shutdown)
     signal.signal(signal.SIGTERM, _handle_shutdown)
@@ -320,6 +337,22 @@ def execute_ingestion(
     succeeded = 0
     failed = 0
     rows_fetched_total = 0
+    resyncs_done = 0
+
+    # Drain symbols queued for full re-sync by a prior run (re-based but not yet
+    # rewritten). These count against the same cap as in-loop detections.
+    universe = set(symbols)
+    for pending in list_pending_resyncs():
+        if pending not in universe:
+            continue
+        if resyncs_done >= max_full_resyncs:
+            break
+        try:
+            if resync_full_history(pending):
+                resyncs_done += 1
+                print(f"[ingestion] drained pending re-sync for {pending}")
+        except Exception as exc:  # isolate drain failures
+            print(f"[ingestion] pending re-sync failed for {pending}: {exc}")
 
     for idx, symbol in enumerate(symbols, start=1):
         latest_symbol_before = get_symbol_latest_date(conn, symbol)
@@ -334,12 +367,52 @@ def execute_ingestion(
             rows_fetched = int(len(df))
             rows_fetched_total += rows_fetched
 
+            rebase_pending = False
             if rows_fetched > 0:
-                save_to_db(df, symbol)
+                # New symbols: full fetch in log mode. Existing symbols: abort
+                # mode so a half-spliced series is never persisted.
+                if latest_symbol_before is None:
+                    save_to_db(df, symbol, on_rebase="log")
+                else:
+                    result = save_to_db(df, symbol, on_rebase="abort")
+                    if result.rebase_detected:
+                        if resyncs_done < max_full_resyncs and resync_full_history(symbol):
+                            resyncs_done += 1
+                            rows_fetched_total += get_symbol_row_count(conn, symbol)
+                        else:
+                            register_pending_resync(symbol)
+                            rebase_pending = True
 
             rows_after = get_symbol_row_count(conn, symbol)
             latest_symbol_after = get_symbol_latest_date(conn, symbol)
             rows_added = max(rows_after - rows_before, 0)
+
+            if rebase_pending:
+                failed += 1
+                save_symbol_result(
+                    conn,
+                    run_id,
+                    SymbolResult(
+                        symbol=symbol,
+                        status="FAILED",
+                        rows_fetched=rows_fetched,
+                        rows_added=rows_added,
+                        latest_before=latest_symbol_before,
+                        latest_after=latest_symbol_after,
+                        error="vendor_rebase_detected_resync_pending",
+                    ),
+                )
+                print(
+                    f"[{idx:04d}/{len(symbols):04d}] {symbol:<12} status=FAILED  "
+                    f"error=vendor_rebase_detected_resync_pending"
+                )
+                if sleep_ms > 0:
+                    time.sleep(sleep_ms / 1000.0)
+                if _shutdown_requested:
+                    print(f"[ingestion] Graceful shutdown after {idx}/{len(symbols)} symbols")
+                    status = "PARTIAL"
+                    break
+                continue
 
             status = "SUCCESS" if rows_fetched > 0 else "NO_DATA"
             save_symbol_result(
@@ -442,6 +515,12 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument("--backfill-days", type=int, default=5, help="Overlap window for existing symbols")
     parser.add_argument("--max-staleness-days", type=int, default=7, help="Freshness SLA")
     parser.add_argument("--sleep-ms", type=int, default=0, help="Optional sleep between symbols")
+    parser.add_argument(
+        "--max-full-resyncs",
+        type=int,
+        default=25,
+        help="Max vendor-rebase full-history re-fetches per run (overflow queued for retry)",
+    )
     parser.add_argument("--strict", action="store_true", help="Fail on non-success run or SLA breach")
     return parser.parse_args(argv)
 
@@ -483,6 +562,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             max_staleness_days=args.max_staleness_days,
             sleep_ms=args.sleep_ms,
             strict=args.strict,
+            max_full_resyncs=args.max_full_resyncs,
         )
     finally:
         conn.close()

--- a/setup_data.py
+++ b/setup_data.py
@@ -101,13 +101,19 @@ def ts(dt: datetime) -> int:
 
 def backfill_symbol(symbol: str, start: datetime, end: datetime) -> int:
     from backend.quant_pro.database import save_to_db
+    from backend.quant_pro.data_io import resync_full_history
     from backend.quant_pro.vendor_api import fetch_ohlcv_chunk
     try:
         df = fetch_ohlcv_chunk(symbol, ts(start), ts(end))
         if df is None or df.empty:
             return 0
         df["symbol"] = symbol
-        save_to_db(df, symbol)
+        # This fetches a rolling window over a possibly-deep DB, so a re-base
+        # written in log mode would splice at the window boundary. Abort instead
+        # and re-fetch the whole series on the new basis.
+        result = save_to_db(df, symbol, on_rebase="abort")
+        if result.rebase_detected:
+            resync_full_history(symbol)
         return len(df)
     except Exception as e:
         print(f"  WARN {symbol}: {e}")

--- a/tests/unit/test_corporate_actions_schema.py
+++ b/tests/unit/test_corporate_actions_schema.py
@@ -1,0 +1,204 @@
+"""Unit tests for the unified corporate_actions schema and refresh path."""
+
+import sqlite3
+from datetime import datetime, date
+
+import pytest
+
+
+def _reset_db(tmp_path, monkeypatch, name="test.db"):
+    db_file = tmp_path / name
+    monkeypatch.setenv("NEPSE_DB_FILE", str(db_file))
+    import backend.quant_pro.database as db_mod
+    db_mod._wal_initialized = False
+    return db_file
+
+
+def _row(symbol="TEST", bookclose=date(2024, 6, 1), description="Cash Dividend 10%"):
+    from backend.quant_pro.corporate_actions import CorporateActionRow
+    return CorporateActionRow(
+        symbol=symbol,
+        fiscal_year="2080/81",
+        bookclose_date_ad=bookclose,
+        description=description,
+        agenda="AGM",
+        cash_dividend_pct=10.0,
+        bonus_share_pct=5.0,
+        right_share_ratio="1:5",
+        source_url="https://merolagani.com/CompanyDetail.aspx?symbol=TEST",
+        scraped_at_utc=datetime(2024, 1, 1, 0, 0, 0),
+    )
+
+
+class TestUnifiedSchema:
+    def test_corp_actions_roundtrip_unified_schema(self, tmp_path, monkeypatch):
+        _reset_db(tmp_path, monkeypatch)
+        from backend.quant_pro.database import init_db, get_db_connection
+        from backend.quant_pro.corporate_actions import (
+            upsert_corporate_actions, load_latest_corporate_actions,
+        )
+        from backend.backtesting.simple_backtest import load_corporate_actions
+
+        init_db()
+        rows = [
+            _row(bookclose=date(2024, 6, 1), description="Cash Dividend 10%"),
+            _row(bookclose=None, description="AGM Notice"),
+        ]
+        n = upsert_corporate_actions(rows)
+        assert n == 2
+
+        loaded = load_latest_corporate_actions("TEST")
+        assert loaded
+        first = loaded[0]
+        for field in (
+            "symbol", "fiscal_year", "bookclose_date", "description", "agenda",
+            "cash_dividend_pct", "bonus_share_pct", "right_share_ratio",
+            "source_url", "scraped_at_utc",
+        ):
+            assert field in first
+
+        conn = get_db_connection()
+        df = load_corporate_actions(conn)
+        conn.close()
+        assert not df.empty
+        assert "bookclose_date" in df.columns
+
+
+class TestMigration:
+    def test_corp_actions_migration_on_legacy_schema_a(self, tmp_path, monkeypatch):
+        db_file = _reset_db(tmp_path, monkeypatch)
+
+        # Schema-A table with a pre-existing row (no description/source_url/scraped_at_utc).
+        conn = sqlite3.connect(str(db_file))
+        conn.execute(
+            '''
+            CREATE TABLE corporate_actions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                symbol TEXT NOT NULL,
+                fiscal_year TEXT,
+                bookclose_date DATE,
+                cash_dividend_pct REAL DEFAULT 0,
+                bonus_share_pct REAL DEFAULT 0,
+                right_share_ratio TEXT,
+                agenda TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(symbol, bookclose_date)
+            )
+            '''
+        )
+        conn.execute(
+            "INSERT INTO corporate_actions (symbol, fiscal_year, bookclose_date, "
+            "cash_dividend_pct, bonus_share_pct, agenda) "
+            "VALUES ('OLD', '2079/80', '2023-06-01', 8.0, 0.0, 'AGM')"
+        )
+        conn.commit()
+        conn.close()
+
+        from backend.quant_pro.database import init_db
+        init_db()
+
+        from backend.quant_pro.corporate_actions import upsert_corporate_actions
+
+        conn = sqlite3.connect(str(db_file))
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(corporate_actions)")}
+        assert {"description", "source_url", "scraped_at_utc"}.issubset(cols)
+        # Old row readable with description IS NULL.
+        old = conn.execute(
+            "SELECT description FROM corporate_actions WHERE symbol='OLD'"
+        ).fetchone()
+        assert old[0] is None
+        conn.close()
+
+        # The previously-crashing upsert path now succeeds.
+        n = upsert_corporate_actions([_row()])
+        assert n == 1
+
+    def test_corp_actions_migration_on_legacy_schema_b(self, tmp_path, monkeypatch):
+        db_file = _reset_db(tmp_path, monkeypatch)
+
+        # Schema-B table (created standalone by the old scraper DDL).
+        conn = sqlite3.connect(str(db_file))
+        conn.execute(
+            '''
+            CREATE TABLE corporate_actions (
+                symbol TEXT NOT NULL,
+                fiscal_year TEXT,
+                bookclose_date DATE,
+                description TEXT,
+                agenda TEXT,
+                cash_dividend_pct REAL,
+                bonus_share_pct REAL,
+                right_share_ratio TEXT,
+                source_url TEXT,
+                scraped_at_utc TEXT NOT NULL,
+                PRIMARY KEY (symbol, fiscal_year, bookclose_date, description)
+            )
+            '''
+        )
+        conn.commit()
+        conn.close()
+
+        from backend.quant_pro.corporate_actions import (
+            upsert_corporate_actions, load_latest_corporate_actions,
+        )
+        from backend.backtesting.simple_backtest import load_corporate_actions
+        from backend.quant_pro.database import get_db_connection
+
+        # Guard adds nothing fatal; upsert + both readers work.
+        n = upsert_corporate_actions([_row()])
+        assert n == 1
+        loaded = load_latest_corporate_actions("TEST")
+        assert loaded
+
+        conn = get_db_connection()
+        df = load_corporate_actions(conn)
+        conn.close()
+        assert not df.empty
+
+
+class TestRefreshIdempotent:
+    def test_corp_actions_refresh_idempotent(self, tmp_path, monkeypatch):
+        _reset_db(tmp_path, monkeypatch)
+        from backend.quant_pro.database import init_db, get_db_connection
+        from backend.quant_pro.corporate_actions import upsert_corporate_actions
+
+        init_db()
+        rows = [
+            _row(bookclose=date(2024, 6, 1), description="Cash Dividend 10%"),
+            _row(bookclose=None, description="AGM Notice"),
+        ]
+        upsert_corporate_actions(rows)
+        conn = get_db_connection()
+        count1 = conn.execute("SELECT COUNT(*) FROM corporate_actions WHERE symbol='TEST'").fetchone()[0]
+        conn.close()
+
+        upsert_corporate_actions(rows)
+        conn = get_db_connection()
+        count2 = conn.execute("SELECT COUNT(*) FROM corporate_actions WHERE symbol='TEST'").fetchone()[0]
+        conn.close()
+        assert count1 == count2
+
+
+class TestMarketService:
+    def test_market_service_reads_description(self, tmp_path, monkeypatch):
+        db_file = _reset_db(tmp_path, monkeypatch)
+        from backend.quant_pro.database import init_db, get_db_connection
+
+        init_db()
+        # Insert an upcoming bookclose so upcoming_corporate_actions returns it.
+        from datetime import timedelta
+        future = (datetime.now().date() + timedelta(days=5)).isoformat()
+        conn = get_db_connection()
+        conn.execute(
+            "INSERT INTO corporate_actions (symbol, fiscal_year, bookclose_date, "
+            "cash_dividend_pct, bonus_share_pct, right_share_ratio, description, "
+            "scraped_at_utc) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("TEST", "2080/81", future, 10.0, 5.0, "1:5", "Cash Dividend 10%", "2024-01-01T00:00:00"),
+        )
+        conn.commit()
+        conn.close()
+
+        from backend.core.services.market import MarketService
+        svc = MarketService(db_path=db_file)
+        actions = svc.upcoming_corporate_actions(days=30)
+        assert any(a["symbol"] == "TEST" and a["description"] == "Cash Dividend 10%" for a in actions)

--- a/tests/unit/test_nepalosint_client.py
+++ b/tests/unit/test_nepalosint_client.py
@@ -1,11 +1,25 @@
 from __future__ import annotations
 
+import pytest
+
 from backend.quant_pro.nepalosint_client import (
     consolidated_stories,
     consolidated_stories_history,
+    related_stories,
     resolve_osint_base_url,
+    semantic_story_search,
+    symbol_intelligence,
     unified_search,
 )
+
+
+def _clear_osint_env(monkeypatch):
+    for name in (
+        "NEPALOSINT_BASE_URL",
+        "NEPALOSINT_API_BASE_URL",
+        "NEPALOSINT_API_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
 
 
 class DummyResponse:
@@ -113,3 +127,40 @@ def test_consolidated_stories_accepts_dict_payloads(monkeypatch):
     stories = consolidated_stories(limit=3)
 
     assert stories == [{"title": "Headline", "url": "https://example.com/story"}]
+
+
+def test_resolve_osint_base_url_disabled_by_default(monkeypatch):
+    _clear_osint_env(monkeypatch)
+
+    assert resolve_osint_base_url() == ""
+
+
+def test_client_functions_noop_without_base(monkeypatch):
+    _clear_osint_env(monkeypatch)
+
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("network call attempted while OSINT is disabled")
+
+    monkeypatch.setattr("backend.quant_pro.nepalosint_client.requests.get", _boom, raising=False)
+    monkeypatch.setattr("backend.quant_pro.nepalosint_client.requests.post", _boom, raising=False)
+
+    assert semantic_story_search("banking")["results"] == []
+    assert unified_search("banking")["categories"] == {}
+    assert consolidated_stories() == []
+    assert consolidated_stories_history(start_date="2025-04-05", end_date="2025-04-05")["items"] == []
+    assert related_stories("story-1")["similar_stories"] == []
+    assert symbol_intelligence("banking")["story_count"] == 0
+
+
+def test_dashboard_osint_helpers_disabled_without_base(monkeypatch):
+    dashboard = pytest.importorskip("apps.tui.dashboard_tui")
+
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("network call attempted while OSINT is disabled")
+
+    monkeypatch.setattr(dashboard, "OSINT_BASE", "", raising=False)
+    monkeypatch.setattr(dashboard._requests, "get", _boom, raising=False)
+    monkeypatch.setattr(dashboard._requests, "post", _boom, raising=False)
+
+    assert dashboard._fetch_osint_stories() == []
+    assert dashboard._fetch_osint_brief() == {}

--- a/tests/unit/test_price_adjustment.py
+++ b/tests/unit/test_price_adjustment.py
@@ -1,0 +1,301 @@
+"""Unit tests for the vendor re-base splice protection in the save path."""
+
+import sqlite3
+
+import pandas as pd
+import pytest
+
+
+def _reset_db(tmp_path, monkeypatch, name="test.db"):
+    db_file = tmp_path / name
+    monkeypatch.setenv("NEPSE_DB_FILE", str(db_file))
+    import backend.quant_pro.database as db_mod
+    db_mod._wal_initialized = False
+    return db_file
+
+
+def _one_row_df(date, close):
+    return pd.DataFrame({
+        "Date": pd.to_datetime([date]),
+        "Open": [close],
+        "High": [close],
+        "Low": [close],
+        "Close": [close],
+        "Volume": [1000.0],
+    })
+
+
+class TestMigration:
+    def test_migration_idempotent_on_legacy_db(self, tmp_path, monkeypatch):
+        db_file = _reset_db(tmp_path, monkeypatch)
+
+        # Hand-create a legacy 7-column stock_prices with rows (pre-migration shape).
+        conn = sqlite3.connect(str(db_file))
+        conn.execute(
+            '''
+            CREATE TABLE stock_prices (
+                symbol TEXT, date DATE, open REAL, high REAL, low REAL,
+                close REAL, volume REAL, PRIMARY KEY (symbol, date)
+            )
+            '''
+        )
+        conn.execute(
+            "INSERT INTO stock_prices VALUES ('TEST', '2024-01-07', 100, 105, 99, 103, 1000)"
+        )
+        conn.commit()
+        conn.close()
+
+        from backend.quant_pro.database import init_db
+        init_db()
+        init_db()  # second run must be a no-op (idempotent)
+
+        conn = sqlite3.connect(str(db_file))
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(stock_prices)")}
+        assert "raw_close" in cols
+
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        assert "price_adjustment_log" in tables
+        assert "pending_full_resync" in tables
+
+        indexes = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index'"
+            )
+        }
+        assert "idx_price_adjustment_log_symbol" in indexes
+
+        # Legacy row should have been eager-backfilled raw_close == close.
+        row = conn.execute(
+            "SELECT close, raw_close FROM stock_prices WHERE symbol='TEST'"
+        ).fetchone()
+        assert row[0] == 103.0
+        assert row[1] == 103.0
+        conn.close()
+
+    def test_save_to_db_runs_migration_itself(self, tmp_path, monkeypatch):
+        db_file = _reset_db(tmp_path, monkeypatch)
+
+        # Fresh DB created only via raw DDL — no init_db.
+        conn = sqlite3.connect(str(db_file))
+        conn.execute(
+            '''
+            CREATE TABLE stock_prices (
+                symbol TEXT, date DATE, open REAL, high REAL, low REAL,
+                close REAL, volume REAL, PRIMARY KEY (symbol, date)
+            )
+            '''
+        )
+        conn.commit()
+        conn.close()
+
+        from backend.quant_pro.database import save_to_db, load_from_db
+        result = save_to_db(_one_row_df("2024-01-07", 100.0), "TEST")
+        assert result.rows_saved == 1
+        loaded = load_from_db("TEST")
+        assert not loaded.empty
+
+
+class TestRawClose:
+    def test_raw_close_survives_rebase(self, tmp_path, monkeypatch):
+        _reset_db(tmp_path, monkeypatch)
+        from backend.quant_pro.database import init_db, save_to_db, get_db_connection
+        init_db()
+
+        save_to_db(_one_row_df("2024-01-07", 100.0), "TEST")
+        save_to_db(_one_row_df("2024-01-07", 90.9), "TEST", on_rebase="log")
+
+        conn = get_db_connection()
+        row = conn.execute(
+            "SELECT close, raw_close FROM stock_prices WHERE symbol='TEST'"
+        ).fetchone()
+        assert row[0] == 90.9
+        assert row[1] == 100.0
+
+        save_to_db(_one_row_df("2024-01-07", 82.6), "TEST", on_rebase="log")
+        row = conn.execute(
+            "SELECT close, raw_close FROM stock_prices WHERE symbol='TEST'"
+        ).fetchone()
+        assert row[0] == 82.6
+        assert row[1] == 100.0  # never overwritten
+        conn.close()
+
+
+class TestAdjustmentLog:
+    def test_adjustment_log_row_correct(self, tmp_path, monkeypatch):
+        _reset_db(tmp_path, monkeypatch)
+        from backend.quant_pro.database import init_db, save_to_db, get_db_connection
+        init_db()
+
+        save_to_db(_one_row_df("2024-01-07", 100.0), "TEST")
+        save_to_db(_one_row_df("2024-01-07", 90.9), "TEST", on_rebase="log")
+
+        conn = get_db_connection()
+        rows = conn.execute(
+            "SELECT old_close, new_close, ratio, reason, detected_at_utc "
+            "FROM price_adjustment_log WHERE symbol='TEST'"
+        ).fetchall()
+        conn.close()
+        assert len(rows) == 1
+        old_close, new_close, ratio, reason, detected_at = rows[0]
+        assert old_close == 100.0
+        assert new_close == 90.9
+        assert ratio == pytest.approx(0.909)
+        assert reason == "resave"
+        # Parseable ISO-8601 timestamp.
+        from datetime import datetime
+        datetime.fromisoformat(detected_at)
+
+    def test_identical_resave_logs_nothing(self, tmp_path, monkeypatch):
+        _reset_db(tmp_path, monkeypatch)
+        from backend.quant_pro.database import init_db, save_to_db, get_db_connection
+        init_db()
+
+        save_to_db(_one_row_df("2024-01-07", 100.0), "TEST")
+        result = save_to_db(_one_row_df("2024-01-07", 100.0), "TEST")
+        assert result.retro_changes == 0
+
+        conn = get_db_connection()
+        count = conn.execute(
+            "SELECT COUNT(*) FROM price_adjustment_log WHERE symbol='TEST'"
+        ).fetchone()[0]
+        conn.close()
+        assert count == 0
+
+    def test_minor_correction_does_not_flag_rebase(self, tmp_path, monkeypatch):
+        _reset_db(tmp_path, monkeypatch)
+        from backend.quant_pro.database import init_db, save_to_db, get_db_connection
+        init_db()
+
+        save_to_db(_one_row_df("2024-01-07", 100.0), "TEST")
+        # +0.0001% change: beyond LOG_TOL but far below REBASE_RTOL.
+        result = save_to_db(
+            _one_row_df("2024-01-07", 100.0001), "TEST", on_rebase="abort"
+        )
+        assert result.retro_changes == 1
+        assert result.rebase_detected is False
+        assert result.rows_saved == 1
+
+        conn = get_db_connection()
+        close = conn.execute(
+            "SELECT close FROM stock_prices WHERE symbol='TEST'"
+        ).fetchone()[0]
+        conn.close()
+        assert close == pytest.approx(100.0001)
+
+
+class TestAbortMode:
+    def test_abort_mode_rolls_back_on_rebase(self, tmp_path, monkeypatch):
+        _reset_db(tmp_path, monkeypatch)
+        from backend.quant_pro.database import init_db, save_to_db, get_db_connection
+        init_db()
+
+        save_to_db(_one_row_df("2024-01-07", 100.0), "TEST")
+        # >0.1% change in an overlap row -> classified as a vendor re-base.
+        result = save_to_db(_one_row_df("2024-01-07", 90.0), "TEST", on_rebase="abort")
+        assert result.rows_saved == 0
+        assert result.rebase_detected is True
+
+        conn = get_db_connection()
+        close = conn.execute(
+            "SELECT close FROM stock_prices WHERE symbol='TEST'"
+        ).fetchone()[0]
+        assert close == 100.0  # prices unchanged
+
+        log_rows = conn.execute(
+            "SELECT reason FROM price_adjustment_log WHERE symbol='TEST'"
+        ).fetchall()
+        conn.close()
+        assert log_rows  # detection evidence WAS committed
+        assert all(r[0] == "rebase_overlap" for r in log_rows)
+
+
+class TestSaveResult:
+    def test_save_result_backward_compatible(self, tmp_path, monkeypatch):
+        _reset_db(tmp_path, monkeypatch)
+        from backend.quant_pro.database import init_db, save_to_db, SaveResult
+        init_db()
+
+        # Default-mode call signature still works and returns a SaveResult.
+        result = save_to_db(_one_row_df("2024-01-07", 100.0), "TEST")
+        assert isinstance(result, SaveResult)
+        assert result.rows_saved == 1
+
+
+class TestOverlapStartDate:
+    def test_get_overlap_start_date(self, tmp_path, monkeypatch):
+        _reset_db(tmp_path, monkeypatch)
+        from backend.quant_pro.database import (
+            init_db, save_to_db, get_overlap_start_date,
+        )
+        init_db()
+
+        # No rows -> None.
+        assert get_overlap_start_date("TEST", 5) is None
+
+        dates = pd.bdate_range("2024-01-01", periods=10)
+        df = pd.DataFrame({
+            "Date": dates,
+            "Open": [100.0] * 10,
+            "High": [100.0] * 10,
+            "Low": [100.0] * 10,
+            "Close": [float(100 + i) for i in range(10)],
+            "Volume": [1000.0] * 10,
+        })
+        save_to_db(df, "TEST")
+
+        # 5th-from-last of 10 bars.
+        expected = dates[-5].strftime("%Y-%m-%d")
+        assert get_overlap_start_date("TEST", 5) == expected
+
+    def test_get_overlap_start_date_fewer_bars(self, tmp_path, monkeypatch):
+        _reset_db(tmp_path, monkeypatch)
+        from backend.quant_pro.database import (
+            init_db, save_to_db, get_overlap_start_date,
+        )
+        init_db()
+
+        dates = pd.bdate_range("2024-01-01", periods=3)
+        df = pd.DataFrame({
+            "Date": dates,
+            "Open": [100.0] * 3,
+            "High": [100.0] * 3,
+            "Low": [100.0] * 3,
+            "Close": [100.0, 101.0, 102.0],
+            "Volume": [1000.0] * 3,
+        })
+        save_to_db(df, "TEST")
+
+        # Fewer than n_bars stored -> oldest bar.
+        assert get_overlap_start_date("TEST", 5) == dates[0].strftime("%Y-%m-%d")
+
+
+class TestPendingResync:
+    def test_pending_resync_helpers(self, tmp_path, monkeypatch):
+        _reset_db(tmp_path, monkeypatch)
+        from backend.quant_pro.database import (
+            init_db, register_pending_resync, list_pending_resyncs,
+            clear_pending_resync, get_db_connection,
+        )
+        init_db()
+
+        register_pending_resync("AAA")
+        register_pending_resync("BBB")
+        assert set(list_pending_resyncs()) == {"AAA", "BBB"}
+
+        # Re-register bumps attempts.
+        register_pending_resync("AAA")
+        conn = get_db_connection()
+        attempts = conn.execute(
+            "SELECT attempts FROM pending_full_resync WHERE symbol='AAA'"
+        ).fetchone()[0]
+        conn.close()
+        assert attempts == 2
+
+        clear_pending_resync("AAA")
+        assert list_pending_resyncs() == ["BBB"]

--- a/tests/unit/test_splice_detection.py
+++ b/tests/unit/test_splice_detection.py
@@ -1,0 +1,392 @@
+"""Unit tests for vendor re-base splice detection in incremental ingestion."""
+
+import sqlite3
+
+import pandas as pd
+import pytest
+
+
+def _reset_db(tmp_path, monkeypatch, name="test.db"):
+    db_file = tmp_path / name
+    monkeypatch.setenv("NEPSE_DB_FILE", str(db_file))
+    import backend.quant_pro.database as db_mod
+    db_mod._wal_initialized = False
+    return db_file
+
+
+def _history_df(dates, base=100.0):
+    closes = [base + i for i in range(len(dates))]
+    return pd.DataFrame({
+        "Date": pd.to_datetime(dates),
+        "Open": closes,
+        "High": [c + 1 for c in closes],
+        "Low": [c - 1 for c in closes],
+        "Close": closes,
+        "Volume": [1000.0] * len(dates),
+    })
+
+
+def _seed_30_bars(monkeypatch):
+    from backend.quant_pro.database import init_db, save_to_db
+    init_db()
+    # 30 trading-ish bars ending a few days ago (before today).
+    dates = pd.bdate_range(end=pd.Timestamp.now().normalize() - pd.Timedelta(days=5), periods=30)
+    df = _history_df([d.strftime("%Y-%m-%d") for d in dates])
+    save_to_db(df, "TEST")
+    return dates
+
+
+class TestSpliceDetection:
+    def test_splice_detection_triggers_full_refetch(self, tmp_path, monkeypatch):
+        _reset_db(tmp_path, monkeypatch)
+        import backend.quant_pro.data_io as dio
+        from backend.quant_pro.database import get_db_connection
+
+        dates = _seed_30_bars(monkeypatch)
+        # Capture the original closes (old basis).
+        old_df = _history_df([d.strftime("%Y-%m-%d") for d in dates])
+        old_closes = {d.strftime("%Y-%m-%d"): c for d, c in zip(dates, old_df["Close"])}
+
+        scale = 1.0 / 1.2  # simulated 20% bonus re-base
+
+        # Overlap (last 5 bars) + 2 new bars, all on the new (scaled) basis.
+        new_dates = list(dates[-5:]) + list(
+            pd.bdate_range(start=dates[-1] + pd.Timedelta(days=1), periods=2)
+        )
+        new_dates = [d.strftime("%Y-%m-%d") for d in new_dates]
+        incr = _history_df(new_dates)
+        incr["Close"] = incr["Close"] * scale
+        incr["Open"] = incr["Open"] * scale
+        incr["High"] = incr["High"] * scale
+        incr["Low"] = incr["Low"] * scale
+        # The overlap bars must carry the SAME closes that the existing bars had
+        # (scaled), so the detector sees a consistent re-base ratio.
+        overlap_scaled = [old_closes[d] * scale for d in new_dates[:5]]
+        for i, c in enumerate(overlap_scaled):
+            incr.iloc[i, incr.columns.get_loc("Close")] = c
+
+        # Full 10y history on the new basis.
+        full = _history_df([d.strftime("%Y-%m-%d") for d in dates] + new_dates[5:])
+        full["Close"] = full["Close"] * scale
+
+        calls = {"full": 0, "incr": 0}
+
+        def fake_fetch_chunk(symbol, start_ts, end_ts):
+            # 10-year range starts far in the past; the overlap range is recent.
+            ten_years_ago = (pd.Timestamp.now() - pd.Timedelta(days=365 * 9)).timestamp()
+            if start_ts < ten_years_ago:
+                calls["full"] += 1
+                return full.copy()
+            calls["incr"] += 1
+            return incr.copy()
+
+        monkeypatch.setattr(dio, "fetch_chunk", fake_fetch_chunk)
+        monkeypatch.setattr(dio, "_is_streamlit_active", lambda: False)
+
+        dio._fetch_dynamic_data("TEST")
+
+        assert calls["incr"] >= 1
+        assert calls["full"] == 1  # full re-fetch happened
+
+        conn = get_db_connection()
+        rows = conn.execute(
+            "SELECT date, close, raw_close FROM stock_prices WHERE symbol='TEST' ORDER BY date"
+        ).fetchall()
+        # Every stored close on the new (scaled) basis.
+        for date_str, close, raw_close in rows:
+            if date_str in old_closes:
+                assert close == pytest.approx(old_closes[date_str] * scale)
+                # raw_close keeps the original basis for the pre-existing bars.
+                assert raw_close == pytest.approx(old_closes[date_str])
+
+        reasons = {
+            r[0]
+            for r in conn.execute(
+                "SELECT DISTINCT reason FROM price_adjustment_log WHERE symbol='TEST'"
+            )
+        }
+        conn.close()
+        assert "rebase_overlap" in reasons
+        assert "full_resync" in reasons
+
+    def test_no_rebase_normal_tail_append(self, tmp_path, monkeypatch):
+        _reset_db(tmp_path, monkeypatch)
+        import backend.quant_pro.data_io as dio
+        from backend.quant_pro.database import get_db_connection
+
+        dates = _seed_30_bars(monkeypatch)
+        old_df = _history_df([d.strftime("%Y-%m-%d") for d in dates])
+        old_closes = {d.strftime("%Y-%m-%d"): c for d, c in zip(dates, old_df["Close"])}
+
+        # Overlap matches exactly; append 2 fresh bars.
+        new_dates = list(dates[-5:]) + list(
+            pd.bdate_range(start=dates[-1] + pd.Timedelta(days=1), periods=2)
+        )
+        new_dates = [d.strftime("%Y-%m-%d") for d in new_dates]
+        incr = _history_df(new_dates)
+        for i, d in enumerate(new_dates[:5]):
+            incr.iloc[i, incr.columns.get_loc("Close")] = old_closes[d]
+
+        calls = {"full": 0, "incr": 0}
+
+        def fake_fetch_chunk(symbol, start_ts, end_ts):
+            ten_years_ago = (pd.Timestamp.now() - pd.Timedelta(days=365 * 9)).timestamp()
+            if start_ts < ten_years_ago:
+                calls["full"] += 1
+            else:
+                calls["incr"] += 1
+            return incr.copy()
+
+        monkeypatch.setattr(dio, "fetch_chunk", fake_fetch_chunk)
+        monkeypatch.setattr(dio, "_is_streamlit_active", lambda: False)
+
+        dio._fetch_dynamic_data("TEST")
+
+        assert calls["full"] == 0  # no full re-fetch
+
+        conn = get_db_connection()
+        log_count = conn.execute(
+            "SELECT COUNT(*) FROM price_adjustment_log WHERE symbol='TEST'"
+        ).fetchone()[0]
+        conn.close()
+        assert log_count == 0  # overlap matched exactly
+
+    def test_full_refetch_failure_fail_closed(self, tmp_path, monkeypatch):
+        _reset_db(tmp_path, monkeypatch)
+        import backend.quant_pro.data_io as dio
+        from backend.quant_pro.database import get_db_connection
+
+        dates = _seed_30_bars(monkeypatch)
+        old_df = _history_df([d.strftime("%Y-%m-%d") for d in dates])
+        old_closes = {d.strftime("%Y-%m-%d"): c for d, c in zip(dates, old_df["Close"])}
+
+        scale = 1.0 / 1.2
+        new_dates = list(dates[-5:]) + list(
+            pd.bdate_range(start=dates[-1] + pd.Timedelta(days=1), periods=2)
+        )
+        new_dates = [d.strftime("%Y-%m-%d") for d in new_dates]
+        incr = _history_df(new_dates)
+        for col in ["Open", "High", "Low", "Close"]:
+            incr[col] = incr[col] * scale
+        for i, d in enumerate(new_dates[:5]):
+            incr.iloc[i, incr.columns.get_loc("Close")] = old_closes[d] * scale
+
+        def fake_fetch_chunk(symbol, start_ts, end_ts):
+            ten_years_ago = (pd.Timestamp.now() - pd.Timedelta(days=365 * 9)).timestamp()
+            if start_ts < ten_years_ago:
+                return pd.DataFrame()  # full re-fetch fails
+            return incr.copy()
+
+        monkeypatch.setattr(dio, "fetch_chunk", fake_fetch_chunk)
+        monkeypatch.setattr(dio, "_is_streamlit_active", lambda: False)
+
+        dio._fetch_dynamic_data("TEST")
+
+        conn = get_db_connection()
+        # DB still on old basis, no tail rows appended.
+        rows = conn.execute(
+            "SELECT date, close FROM stock_prices WHERE symbol='TEST' ORDER BY date"
+        ).fetchall()
+        stored = {d: c for d, c in rows}
+        for d, c in old_closes.items():
+            assert stored[d] == pytest.approx(c)
+        # New tail bars were never written.
+        assert new_dates[5] not in stored
+
+        pending = conn.execute(
+            "SELECT symbol FROM pending_full_resync"
+        ).fetchall()
+        conn.close()
+        assert ("TEST",) in pending
+
+
+class TestIngestionHook:
+    def test_ingestion_marks_failed_and_requeues(self, tmp_path, monkeypatch):
+        _reset_db(tmp_path, monkeypatch)
+        import backend.quant_pro.data_io as dio
+        from scripts.ingestion import deterministic_daily_ingestion as ddi
+        from backend.quant_pro.database import get_db_connection
+
+        dates = _seed_30_bars(monkeypatch)
+        old_df = _history_df([d.strftime("%Y-%m-%d") for d in dates])
+        old_closes = {d.strftime("%Y-%m-%d"): c for d, c in zip(dates, old_df["Close"])}
+
+        scale = 1.0 / 1.2
+        new_dates = list(dates[-5:]) + list(
+            pd.bdate_range(start=dates[-1] + pd.Timedelta(days=1), periods=2)
+        )
+        new_dates = [d.strftime("%Y-%m-%d") for d in new_dates]
+        incr = _history_df(new_dates)
+        for col in ["Open", "High", "Low", "Close"]:
+            incr[col] = incr[col] * scale
+        for i, d in enumerate(new_dates[:5]):
+            incr.iloc[i, incr.columns.get_loc("Close")] = old_closes[d] * scale
+
+        # ddi fetches via fetch_ohlcv_chunk; resync uses data_io.fetch_chunk (fails).
+        monkeypatch.setattr(ddi, "fetch_ohlcv_chunk", lambda symbol, start_ts, end_ts: incr.copy())
+        monkeypatch.setattr(dio, "fetch_chunk", lambda symbol, start_ts, end_ts: pd.DataFrame())
+
+        conn = get_db_connection()
+        ddi.execute_ingestion(
+            conn=conn,
+            symbols=["TEST"],
+            source="db",
+            history_days=3650,
+            backfill_days=5,
+            max_staleness_days=7,
+            sleep_ms=0,
+            strict=False,
+        )
+
+        row = conn.execute(
+            "SELECT status, error FROM ingestion_run_symbols WHERE symbol='TEST'"
+        ).fetchone()
+        assert row[0] == "FAILED"
+        assert "vendor_rebase_detected_resync_pending" in (row[1] or "")
+
+        pending = conn.execute("SELECT symbol FROM pending_full_resync").fetchall()
+        assert ("TEST",) in pending
+
+        # Next run drains the pending queue (now the full fetch succeeds).
+        full = _history_df([d.strftime("%Y-%m-%d") for d in dates] + new_dates[5:])
+        for col in ["Open", "High", "Low", "Close"]:
+            full[col] = full[col] * scale
+        monkeypatch.setattr(dio, "fetch_chunk", lambda symbol, start_ts, end_ts: full.copy())
+        # Make the next run's tail fetch a clean (matching) overlap to avoid a new rebase.
+        clean_incr = _history_df([d.strftime("%Y-%m-%d") for d in dates[-5:]])
+        for col in ["Open", "High", "Low", "Close"]:
+            clean_incr[col] = clean_incr[col] * scale
+        for i, d in enumerate([dd.strftime("%Y-%m-%d") for dd in dates[-5:]]):
+            clean_incr.iloc[i, clean_incr.columns.get_loc("Close")] = old_closes[d] * scale
+        monkeypatch.setattr(ddi, "fetch_ohlcv_chunk", lambda symbol, start_ts, end_ts: clean_incr.copy())
+
+        ddi.execute_ingestion(
+            conn=conn,
+            symbols=["TEST"],
+            source="db",
+            history_days=3650,
+            backfill_days=5,
+            max_staleness_days=7,
+            sleep_ms=0,
+            strict=False,
+        )
+        pending_after = conn.execute("SELECT symbol FROM pending_full_resync").fetchall()
+        conn.close()
+        assert ("TEST",) not in pending_after  # drained
+
+    def test_max_full_resyncs_cap(self, tmp_path, monkeypatch):
+        _reset_db(tmp_path, monkeypatch)
+        import backend.quant_pro.data_io as dio
+        from scripts.ingestion import deterministic_daily_ingestion as ddi
+        from backend.quant_pro.database import init_db, save_to_db, get_db_connection
+
+        init_db()
+        scale = 1.0 / 1.2
+        symbols = ["AAA", "BBB", "CCC"]
+        per_symbol = {}
+        for sym in symbols:
+            dates = pd.bdate_range(
+                end=pd.Timestamp.now().normalize() - pd.Timedelta(days=5), periods=30
+            )
+            df = _history_df([d.strftime("%Y-%m-%d") for d in dates])
+            save_to_db(df, sym)
+            old_closes = {d.strftime("%Y-%m-%d"): c for d, c in zip(dates, df["Close"])}
+            new_dates = [d.strftime("%Y-%m-%d") for d in dates[-5:]] + [
+                d.strftime("%Y-%m-%d")
+                for d in pd.bdate_range(start=dates[-1] + pd.Timedelta(days=1), periods=2)
+            ]
+            incr = _history_df(new_dates)
+            for col in ["Open", "High", "Low", "Close"]:
+                incr[col] = incr[col] * scale
+            for i, d in enumerate(new_dates[:5]):
+                incr.iloc[i, incr.columns.get_loc("Close")] = old_closes[d] * scale
+            per_symbol[sym] = incr
+
+        def fake_ohlcv(symbol, start_ts, end_ts):
+            return per_symbol[symbol].copy()
+
+        # Resync full fetch always succeeds (returns scaled history).
+        def fake_full(symbol, start_ts, end_ts):
+            dates = pd.bdate_range(
+                end=pd.Timestamp.now().normalize() - pd.Timedelta(days=3), periods=32
+            )
+            df = _history_df([d.strftime("%Y-%m-%d") for d in dates])
+            for col in ["Open", "High", "Low", "Close"]:
+                df[col] = df[col] * scale
+            return df
+
+        monkeypatch.setattr(ddi, "fetch_ohlcv_chunk", fake_ohlcv)
+        monkeypatch.setattr(dio, "fetch_chunk", fake_full)
+
+        conn = get_db_connection()
+        ddi.execute_ingestion(
+            conn=conn,
+            symbols=symbols,
+            source="db",
+            history_days=3650,
+            backfill_days=5,
+            max_staleness_days=7,
+            sleep_ms=0,
+            strict=False,
+            max_full_resyncs=1,
+        )
+        pending = {r[0] for r in conn.execute("SELECT symbol FROM pending_full_resync")}
+        conn.close()
+        # One resynced inline, the other two queued.
+        assert len(pending) == 2
+
+
+class TestBackfillSymbol:
+    def test_backfill_symbol_abort_and_resync(self, tmp_path, monkeypatch):
+        _reset_db(tmp_path, monkeypatch)
+        import setup_data
+        import backend.quant_pro.data_io as dio
+        from backend.quant_pro.database import init_db, save_to_db, get_db_connection
+        import backend.quant_pro.vendor_api as vendor_api
+
+        init_db()
+        # Deep DB (older history).
+        dates = pd.bdate_range(end=pd.Timestamp.now().normalize() - pd.Timedelta(days=5), periods=60)
+        df = _history_df([d.strftime("%Y-%m-%d") for d in dates])
+        save_to_db(df, "TEST")
+        old_closes = {d.strftime("%Y-%m-%d"): c for d, c in zip(dates, df["Close"])}
+
+        scale = 1.0 / 1.2
+        # 760-day window fetch returns a re-based slice that overlaps stored bars.
+        window = _history_df([d.strftime("%Y-%m-%d") for d in dates[-20:]])
+        for col in ["Open", "High", "Low", "Close"]:
+            window[col] = window[col] * scale
+        for i, d in enumerate([dd.strftime("%Y-%m-%d") for dd in dates[-20:]]):
+            window.iloc[i, window.columns.get_loc("Close")] = old_closes[d] * scale
+
+        resync_called = {"n": 0}
+
+        def fake_full(symbol, start_ts, end_ts):
+            resync_called["n"] += 1
+            full = _history_df([d.strftime("%Y-%m-%d") for d in dates])
+            for col in ["Open", "High", "Low", "Close"]:
+                full[col] = full[col] * scale
+            return full
+
+        monkeypatch.setattr(vendor_api, "fetch_ohlcv_chunk", lambda symbol, s, e: window.copy())
+        monkeypatch.setattr(
+            setup_data, "fetch_ohlcv_chunk", lambda symbol, s, e: window.copy(), raising=False
+        )
+        monkeypatch.setattr(dio, "fetch_chunk", fake_full)
+
+        from datetime import datetime, timedelta
+        end = datetime.now()
+        start = end - timedelta(days=760)
+        setup_data.backfill_symbol("TEST", start, end)
+
+        assert resync_called["n"] == 1  # full resync invoked
+
+        conn = get_db_connection()
+        # No window-boundary splice: all stored closes on the new basis.
+        rows = conn.execute(
+            "SELECT date, close FROM stock_prices WHERE symbol='TEST' ORDER BY date"
+        ).fetchall()
+        for d, c in rows:
+            if d in old_closes:
+                assert c == pytest.approx(old_closes[d] * scale)
+        conn.close()

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -23,6 +23,8 @@ from validation.monte_carlo import (
     BootstrapResult,
 )
 from validation.kill_switch import KillSwitch, KillReason
+from validation.run_all import resolve_config_kwargs, LEGACY_CONFIG_KWARGS
+from configs.long_term import LONG_TERM_CONFIG
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -339,3 +341,45 @@ class TestKillSwitch:
             daily_pnl=-5_000, daily_start_nav=1_000_000,
         )
         assert halt is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Config Selection
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestResolveConfigKwargs:
+    """Config selection for the validation runner."""
+
+    def test_default_is_shipped_c5_baseline(self):
+        """The default 'long_term' config must be the shipped 6-signal C5 baseline."""
+        kwargs = resolve_config_kwargs("long_term")
+        assert kwargs["signal_types"] == LONG_TERM_CONFIG["signal_types"]
+        assert len(kwargs["signal_types"]) == 6
+        assert "quarterly_fundamental" in kwargs["signal_types"]
+        assert "xsec_momentum" in kwargs["signal_types"]
+        assert kwargs["holding_days"] == LONG_TERM_CONFIG["holding_days"]
+        assert kwargs["max_positions"] == LONG_TERM_CONFIG["max_positions"]
+
+    def test_long_term_does_not_mutate_source_config(self):
+        """Resolving must return a copy, not the live LONG_TERM_CONFIG dict."""
+        kwargs = resolve_config_kwargs("long_term")
+        kwargs["holding_days"] = 999
+        assert LONG_TERM_CONFIG["holding_days"] != 999
+
+    def test_long_term_runnable_with_trailing_stop(self):
+        """C5 config must carry use_trailing_stop for the backtest call."""
+        kwargs = resolve_config_kwargs("long_term")
+        assert kwargs["use_trailing_stop"] is True
+
+    def test_legacy_is_three_signal_config(self):
+        """'legacy' must reproduce the old 3-signal volume/quality/low_vol config."""
+        kwargs = resolve_config_kwargs("legacy")
+        assert kwargs["signal_types"] == ["volume", "quality", "low_vol"]
+        assert kwargs == LEGACY_CONFIG_KWARGS
+
+    def test_legacy_does_not_mutate_template(self):
+        """Resolving 'legacy' must return a copy of the template."""
+        kwargs = resolve_config_kwargs("legacy")
+        kwargs["max_positions"] = 999
+        assert LEGACY_CONFIG_KWARGS["max_positions"] != 999

--- a/validation/run_all.py
+++ b/validation/run_all.py
@@ -723,6 +723,40 @@ def run_full_validation(
     return full_results
 
 
+# Legacy 3-signal config (the suite's historical default before --config existed).
+LEGACY_CONFIG_KWARGS = {
+    "holding_days": 40,
+    "max_positions": 5,
+    "signal_types": ["volume", "quality", "low_vol"],
+    "initial_capital": 1_000_000,
+    "rebalance_frequency": 5,
+    "use_trailing_stop": True,
+    "trailing_stop_pct": 0.10,
+    "stop_loss_pct": 0.08,
+    "use_regime_filter": True,
+    "sector_limit": 0.35,
+    "regime_max_positions": None,
+    "bear_threshold": -0.05,
+}
+
+
+def resolve_config_kwargs(config_name: str) -> dict:
+    """Return run_backtest kwargs for the named config selection.
+
+    'long_term' = the shipped 6-signal C5 baseline (configs/long_term.py
+    LONG_TERM_CONFIG), the strategy the engine actually trades. 'legacy' =
+    the old 3-signal volume/quality/low_vol config.
+    """
+    if config_name == "legacy":
+        return dict(LEGACY_CONFIG_KWARGS)
+
+    from configs.long_term import LONG_TERM_CONFIG
+
+    kwargs = dict(LONG_TERM_CONFIG)
+    kwargs.setdefault("use_trailing_stop", True)
+    return kwargs
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="NEPSE Trading System — Production Readiness Validation"
@@ -731,12 +765,22 @@ def main():
     parser.add_argument("--end", default="2025-12-31", help="End date (YYYY-MM-DD)")
     parser.add_argument("--output", default="reports/validation", help="Output directory")
     parser.add_argument("--fast", action="store_true", help="Fast mode (fewer simulations)")
-    parser.add_argument("--holding-days", type=int, default=40, help="Holding period")
-    parser.add_argument("--max-positions", type=int, default=5, help="Max positions")
+    parser.add_argument(
+        "--config", default="long_term", choices=["long_term", "legacy"],
+        help=(
+            "Strategy config to validate. 'long_term' = the shipped 6-signal C5 "
+            "baseline (configs/long_term.py LONG_TERM_CONFIG, default); "
+            "'legacy' = the old 3-signal volume/quality/low_vol config"
+        ),
+    )
+    # Strategy-shaping overrides default to None so the chosen --config supplies
+    # the value; pass them explicitly to override the config.
+    parser.add_argument("--holding-days", type=int, default=None, help="Holding period (overrides --config)")
+    parser.add_argument("--max-positions", type=int, default=None, help="Max positions (overrides --config)")
     parser.add_argument(
         "--signals", nargs="+",
-        default=["volume", "quality", "low_vol"],
-        help="Signal types"
+        default=None,
+        help="Signal types (overrides --config)"
     )
     parser.add_argument(
         "--workers", type=int, default=1,
@@ -751,18 +795,32 @@ def main():
         help='Graduated regime position limits, e.g. "bull:5,neutral:4,bear:1"'
     )
     parser.add_argument(
-        "--bear-threshold", type=float, default=-0.05,
-        help="Bear regime threshold (default: -0.05, tighter: -0.03)"
+        "--bear-threshold", type=float, default=None,
+        help="Bear regime threshold (overrides --config; tighter: -0.03)"
     )
     args = parser.parse_args()
 
-    # Parse regime position limits
-    regime_max_positions = None
+    # Build the backtest kwargs from the selected config, then apply explicit
+    # CLI overrides on top. The default config is the shipped 6-signal C5
+    # baseline, so the suite validates the strategy the engine actually trades.
+    backtest_kwargs = resolve_config_kwargs(args.config)
+
+    if args.holding_days is not None:
+        backtest_kwargs["holding_days"] = args.holding_days
+    if args.max_positions is not None:
+        backtest_kwargs["max_positions"] = args.max_positions
+    if args.signals is not None:
+        backtest_kwargs["signal_types"] = args.signals
+    if args.bear_threshold is not None:
+        backtest_kwargs["bear_threshold"] = args.bear_threshold
+
+    # Parse regime position limits (overrides the config when supplied)
     if args.regime_positions:
         regime_max_positions = {}
         for pair in args.regime_positions.split(","):
             regime, count = pair.strip().split(":")
             regime_max_positions[regime.strip()] = int(count.strip())
+        backtest_kwargs["regime_max_positions"] = regime_max_positions
 
     results = run_full_validation(
         start_date=args.start,
@@ -771,18 +829,7 @@ def main():
         fast_mode=args.fast,
         max_workers=args.workers,
         fast_baseline=args.fast_baseline,
-        holding_days=args.holding_days,
-        max_positions=args.max_positions,
-        signal_types=args.signals,
-        initial_capital=1_000_000,
-        rebalance_frequency=5,
-        use_trailing_stop=True,
-        trailing_stop_pct=0.10,
-        stop_loss_pct=0.08,
-        use_regime_filter=True,
-        sector_limit=0.35,
-        regime_max_positions=regime_max_positions,
-        bear_threshold=args.bear_threshold,
+        **backtest_kwargs,
     )
 
     sys.exit(0 if results["go_nogo"] == "GO" else 1)


### PR DESCRIPTION
Three related hardening changes, one commit each.

## 1. OSINT and Telegram integrations are now optional and disabled by default
- Removes the hardcoded OSINT endpoint from the dashboard. The base URL now comes from `NEPSE_OSINT_BASE` (dashboard) / `NEPALOSINT_BASE_URL` (client); with nothing set, all OSINT helpers no-op and make zero network calls.
- `nepalosint_client` no longer defaults to a remote service. The MCP server and analyst agent degrade to no-op stubs if the client is unavailable; the live trader treats `telegram_alerts` as optional.

## 2. Vendor re-based price history is detected instead of silently spliced
The vendor feed delivers adjusted prices, so a bonus/rights event re-bases the entire history. Tail-only incremental updates spliced old-basis rows onto new-basis rows, silently corrupting every affected series and any backtest on it.
- Incremental fetches now overlap the last 5 stored bars and compare closes; on a detected re-base the save aborts and the symbol's full history is re-fetched (capped per run via `--max-full-resyncs`, overflow queued in `pending_full_resync`).
- `stock_prices` gains a `raw_close` column preserving first-seen closes; every retroactive rewrite is recorded in `price_adjustment_log`.
- Unifies the two conflicting `corporate_actions` schemas between `database.py` and `corporate_actions.py`, making the refresh path runnable again.
- All migrations are idempotent and self-applying on both init and save paths — existing DBs and the bundled DB upgrade transparently.

## 3. Honest performance framing + validation of the shipped config
- README now carries an explicit research/education disclaimer; the headline C5 figure is described as what it is: an in-sample sweep result, not corrected for multiple testing.
- Known engine optimism is documented (zero slippage, band fills on circuit-locked days, survivors-only universe), with a new `docs/VALIDATION_METHODOLOGY.md` covering what the validation suite does and does not establish.
- `validation/run_all.py` now validates the shipped 6-signal C5 baseline by default, so the documented command tests the strategy the README describes.
- Fixes the quick-start backtest example (missing required dates) and the stale Sun–Thu trading-week claim.

## Testing
- Full unit suite: 329 passed (22 new tests for re-base detection, adjustment logging, migration idempotency, and corporate-actions schema; 3 for the disabled-by-default OSINT contract; 5 for validation config selection).
- Verified end-to-end: a simulated re-based feed triggers exactly one detection + full re-fetch, with `raw_close` preserved and a consistent final series.
- Migration tested twice-over on legacy-shaped DBs (no `raw_close`, old corp-actions schema).